### PR TITLE
Normalize indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*.cs]
+end_of_line = crlf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/BaseHandlers/AptData.cs
+++ b/BaseHandlers/AptData.cs
@@ -706,19 +706,19 @@ namespace BaseHandlers
             Constants = new List<AptConst>();
         }
 
-		private void Clear()
-		{
-			Component1Name = default;
-			Component2Name = default;
+        private void Clear()
+        {
+            Component1Name = default;
+            Component2Name = default;
 
-			RootMovie = default;
+            RootMovie = default;
 
-			Constants.Clear();
-		}
+            Constants.Clear();
+        }
 
         public bool Read(BundleEntry entry, ILoader loader = null)
         {
-			Clear();
+            Clear();
 
             MemoryStream ms = entry.MakeStream();
             BinaryReader2 br = new BinaryReader2(ms);
@@ -735,7 +735,7 @@ namespace BaseHandlers
             for (int i = 0; i < numPadding; i++)
                 br.ReadByte();*/
 
-			br.BaseStream.Position = componentName1Ptr;
+            br.BaseStream.Position = componentName1Ptr;
             Component1Name = br.ReadCStr();
             br.BaseStream.Position = componentName2Ptr;
             Component2Name = br.ReadCStr();
@@ -797,17 +797,17 @@ namespace BaseHandlers
             entry.EntryBlocks[0].Data = data;
             entry.Dirty = true;
 
-			return true;
+            return true;
         }
 
-		public EntryType GetEntryType(BundleEntry entry)
-		{
-			return EntryType.AptData;
-		}
+        public EntryType GetEntryType(BundleEntry entry)
+        {
+            return EntryType.AptData;
+        }
 
-		public IEntryEditor GetEditor(BundleEntry entry)
-		{
-			return null;
-		}
-	}
+        public IEntryEditor GetEditor(BundleEntry entry)
+        {
+            return null;
+        }
+    }
 }

--- a/BaseHandlers/BasePlugin.cs
+++ b/BaseHandlers/BasePlugin.cs
@@ -12,131 +12,131 @@ using System.Windows.Forms;
 
 namespace BaseHandlers
 {
-	public class BasePlugin : Plugin
-	{
-		public override void Init()
-		{
-			EntryTypeRegistry.Register(EntryType.TriggerData, new TriggerData());
-			EntryTypeRegistry.Register(EntryType.StreetData, new StreetData());
-			EntryTypeRegistry.Register(EntryType.ProgressionData, new ProgressionData());
-			EntryTypeRegistry.Register(EntryType.EntryList, new IDList());
-			EntryTypeRegistry.Register(EntryType.TrafficData, new Traffic());
-			EntryTypeRegistry.Register(EntryType.FlaptFile, new FlaptFile());
-			//EntryTypeRegistry.Register(EntryType.AptDataHeaderType, new AptData());
-			EntryTypeRegistry.Register(EntryType.InstanceList, new InstanceList());
-			EntryTypeRegistry.Register(EntryType.GraphicsSpec, new GraphicsSpec());
-			EntryTypeRegistry.Register(EntryType.Renderable, new Renderable());
-		}
+    public class BasePlugin : Plugin
+    {
+        public override void Init()
+        {
+            EntryTypeRegistry.Register(EntryType.TriggerData, new TriggerData());
+            EntryTypeRegistry.Register(EntryType.StreetData, new StreetData());
+            EntryTypeRegistry.Register(EntryType.ProgressionData, new ProgressionData());
+            EntryTypeRegistry.Register(EntryType.EntryList, new IDList());
+            EntryTypeRegistry.Register(EntryType.TrafficData, new Traffic());
+            EntryTypeRegistry.Register(EntryType.FlaptFile, new FlaptFile());
+            //EntryTypeRegistry.Register(EntryType.AptDataHeaderType, new AptData());
+            EntryTypeRegistry.Register(EntryType.InstanceList, new InstanceList());
+            EntryTypeRegistry.Register(EntryType.GraphicsSpec, new GraphicsSpec());
+            EntryTypeRegistry.Register(EntryType.Renderable, new Renderable());
+        }
 
-		public override string GetID()
-		{
-			return "baseplugin";
-		}
+        public override string GetID()
+        {
+            return "baseplugin";
+        }
 
-		public override string GetName()
-		{
-			return "Base Resource Handlers";
-		}
+        public override string GetName()
+        {
+            return "Base Resource Handlers";
+        }
 
-		#region Extra Tools
+        #region Extra Tools
 
-		/*public void ConvertImagesFromPS3ToPC_old(IWin32Window window, BundleArchive archive)
-		{
-			if (archive == null)
-			{
-				MessageBox.Show(window, "No Archive Open!", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-				return;
-			}
-			if (archive.Console)
-			{
-				for (int i = 0; i < archive.Entries.Count; i++)
-				{
-					BundleEntry entry = archive.Entries[i];
-					if (entry.EntryBlocks[0].Data.Length == 48 && entry.EntryBlocks[1].Data != null && entry.EntryBlocks[1].Data.Length > 0)
-					{
-						MemoryStream ms = new MemoryStream(entry.EntryBlocks[0].Data);
-						BinaryReader2 br = new BinaryReader2(ms);
-						br.BigEndian = entry.Console;
+        /*public void ConvertImagesFromPS3ToPC_old(IWin32Window window, BundleArchive archive)
+        {
+            if (archive == null)
+            {
+                MessageBox.Show(window, "No Archive Open!", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+            if (archive.Console)
+            {
+                for (int i = 0; i < archive.Entries.Count; i++)
+                {
+                    BundleEntry entry = archive.Entries[i];
+                    if (entry.EntryBlocks[0].Data.Length == 48 && entry.EntryBlocks[1].Data != null && entry.EntryBlocks[1].Data.Length > 0)
+                    {
+                        MemoryStream ms = new MemoryStream(entry.EntryBlocks[0].Data);
+                        BinaryReader2 br = new BinaryReader2(ms);
+                        br.BigEndian = entry.Console;
 
-						byte compression = br.ReadByte();
-						byte[] unknown1 = br.ReadBytes(3);
-						byte[] type = Encoding.ASCII.GetBytes("DXT1");
-						if (compression == 0x85)
-						{
-							type = new byte[] { 0x15, 0x00, 0x00, 0x00 };
-						}
-						else if (compression == 0x86)
-						{
-							type = Encoding.ASCII.GetBytes("DXT1");
-						}
-						else if (compression == 0x88)
-						{
-							type = Encoding.ASCII.GetBytes("DXT5");
-						}
-						int unknown2 = Util.ReverseBytes(br.ReadInt32());
-						int width = Util.ReverseBytes(br.ReadInt16());
-						int height = Util.ReverseBytes(br.ReadInt16());
-						br.Close();
+                        byte compression = br.ReadByte();
+                        byte[] unknown1 = br.ReadBytes(3);
+                        byte[] type = Encoding.ASCII.GetBytes("DXT1");
+                        if (compression == 0x85)
+                        {
+                            type = new byte[] { 0x15, 0x00, 0x00, 0x00 };
+                        }
+                        else if (compression == 0x86)
+                        {
+                            type = Encoding.ASCII.GetBytes("DXT1");
+                        }
+                        else if (compression == 0x88)
+                        {
+                            type = Encoding.ASCII.GetBytes("DXT5");
+                        }
+                        int unknown2 = Util.ReverseBytes(br.ReadInt32());
+                        int width = Util.ReverseBytes(br.ReadInt16());
+                        int height = Util.ReverseBytes(br.ReadInt16());
+                        br.Close();
 
-						MemoryStream msx = new MemoryStream();
-						BinaryWriter bw = new BinaryWriter(msx);
+                        MemoryStream msx = new MemoryStream();
+                        BinaryWriter bw = new BinaryWriter(msx);
 
-						bw.Write((int)0);
-						bw.Write((int)0);
-						bw.Write((int)0);
-						bw.Write((int)1);
+                        bw.Write((int)0);
+                        bw.Write((int)0);
+                        bw.Write((int)0);
+                        bw.Write((int)1);
 
-						bw.Write(type);
-						bw.Write((short)width);
-						bw.Write((short)height);
-						bw.Write((int)0x15);
-						bw.Write((int)0);
+                        bw.Write(type);
+                        bw.Write((short)width);
+                        bw.Write((short)height);
+                        bw.Write((int)0x15);
+                        bw.Write((int)0);
 
-						bw.Flush();
+                        bw.Flush();
 
-						byte[] Data = msx.ToArray();
+                        byte[] Data = msx.ToArray();
 
-						bw.Close();
+                        bw.Close();
 
-						entry.EntryBlocks[0].Data = Data;
+                        entry.EntryBlocks[0].Data = Data;
 
-						entry.Dirty = true;
-					}
-				}
-			}
-			else
-			{
-				MessageBox.Show(window, "This feature only works on PS3 Bundle Files", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-			}
-		}
+                        entry.Dirty = true;
+                    }
+                }
+            }
+            else
+            {
+                MessageBox.Show(window, "This feature only works on PS3 Bundle Files", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
+        }
 
-		public void ConvertToPC(IWin32Window window, BundleArchive archive)
-		{
-			// TODO: Support everything
+        public void ConvertToPC(IWin32Window window, BundleArchive archive)
+        {
+            // TODO: Support everything
 
-			for (int i = 0; i < archive.Entries.Count; i++)
-			{
-				BundleEntry entry = archive.Entries[i];
+            for (int i = 0; i < archive.Entries.Count; i++)
+            {
+                BundleEntry entry = archive.Entries[i];
 
-				if (entry.Type == EntryType.IDList)
-				{
-					IDList list = new IDList();
-					list.Read(entry);
-					list.Write(entry);
-				}
-				else if (entry.Type == EntryType.PolygonSoupListResourceType)
-				{
-					PolygonSoupList list = new PolygonSoupList();
-					list.Read(entry);
-					list.Write(entry);
-				}
-			}
+                if (entry.Type == EntryType.IDList)
+                {
+                    IDList list = new IDList();
+                    list.Read(entry);
+                    list.Write(entry);
+                }
+                else if (entry.Type == EntryType.PolygonSoupListResourceType)
+                {
+                    PolygonSoupList list = new PolygonSoupList();
+                    list.Read(entry);
+                    list.Write(entry);
+                }
+            }
 
-			//PatchImages();
+            //PatchImages();
 
-			archive.Platform = BundlePlatform.PC;
-		}*/
+            archive.Platform = BundlePlatform.PC;
+        }*/
 
-		#endregion
-	}
+        #endregion
+    }
 }

--- a/BaseHandlers/FlaptFile.cs
+++ b/BaseHandlers/FlaptFile.cs
@@ -139,45 +139,45 @@ namespace BaseHandlers
             CharacterRefStrings = new List<StringPointer>();
         }
 
-		private void Clear()
-		{
-			FileSize = default;
-			SecondsPerFrame = default;
-			Section1RecordCount = default;
-			Section1Offset = default;
-			ImageIDCount = default;
-			ImageIDListOffset = default;
-			GeometryVerticesCount = default;
-			GeometryVerticesOffset = default;
-			TextStyleCount = default;
-			TextStyleListOffset = default;
-			Section5And6RecordCount = default;
-			Section5Offset = default;
-			Section6Offset = default;
-			EventBindsCount = default;
-			EventBindsOffset = default;
-			TextStringsCount = default;
-			TextStringsOffset = default;
-			DependencyRefStringsCount = default;
-			DependencyRefStringsOffset = default;
-			CharacterRefStringsCount = default;
-			CharacterRefStringsOffset = default;
+        private void Clear()
+        {
+            FileSize = default;
+            SecondsPerFrame = default;
+            Section1RecordCount = default;
+            Section1Offset = default;
+            ImageIDCount = default;
+            ImageIDListOffset = default;
+            GeometryVerticesCount = default;
+            GeometryVerticesOffset = default;
+            TextStyleCount = default;
+            TextStyleListOffset = default;
+            Section5And6RecordCount = default;
+            Section5Offset = default;
+            Section6Offset = default;
+            EventBindsCount = default;
+            EventBindsOffset = default;
+            TextStringsCount = default;
+            TextStringsOffset = default;
+            DependencyRefStringsCount = default;
+            DependencyRefStringsOffset = default;
+            CharacterRefStringsCount = default;
+            CharacterRefStringsOffset = default;
 
-			Section1Entries.Clear();
-			ImageIDs.Clear();
-			GeometryVertices.Clear();
-			TextStyleEntries.Clear();
-			Section5Entries.Clear();
-			Section6Entries.Clear();
-			EventBinds.Clear();
-			TextStrings.Clear();
-			DependencyRefStrings.Clear();
-			CharacterRefStrings.Clear();
-		}
+            Section1Entries.Clear();
+            ImageIDs.Clear();
+            GeometryVertices.Clear();
+            TextStyleEntries.Clear();
+            Section5Entries.Clear();
+            Section6Entries.Clear();
+            EventBinds.Clear();
+            TextStrings.Clear();
+            DependencyRefStrings.Clear();
+            CharacterRefStrings.Clear();
+        }
 
         public bool Read(BundleEntry entry, ILoader loader = null)
         {
-			Clear();
+            Clear();
 
             MemoryStream ms = entry.MakeStream();
             BinaryReader2 br = new BinaryReader2(ms);
@@ -426,18 +426,18 @@ namespace BaseHandlers
 
         public bool Write(BundleEntry entry)
         {
-			// TODO
-			return true;
+            // TODO
+            return true;
         }
 
-		public EntryType GetEntryType(BundleEntry entry)
-		{
-			return EntryType.FlaptFile;
-		}
+        public EntryType GetEntryType(BundleEntry entry)
+        {
+            return EntryType.FlaptFile;
+        }
 
-		public IEntryEditor GetEditor(BundleEntry entry)
-		{
-			return null;
-		}
-	}
+        public IEntryEditor GetEditor(BundleEntry entry)
+        {
+            return null;
+        }
+    }
 }

--- a/BaseHandlers/GraphicsSpec.cs
+++ b/BaseHandlers/GraphicsSpec.cs
@@ -11,10 +11,10 @@ using PluginAPI;
 namespace BaseHandlers
 {
     public class GraphicsSpec : IEntryData
-	{
-		private Scene _scene;
+    {
+        private Scene _scene;
 
-		public BundleEntry Entry;
+        public BundleEntry Entry;
 
         public int Unknown1;
         public List<ulong> Instances;
@@ -26,22 +26,22 @@ namespace BaseHandlers
             Instances = new List<ulong>();
         }
 
-		private void Clear()
-		{
-			_scene = null;
+        private void Clear()
+        {
+            _scene = null;
 
-			Entry = default;
+            Entry = default;
 
-			Unknown1 = default;
-			Unknown2 = default;
-			Unknown3 = default;
+            Unknown1 = default;
+            Unknown2 = default;
+            Unknown3 = default;
 
-			Instances.Clear();
-		}
+            Instances.Clear();
+        }
 
         public bool Read(BundleEntry entry, ILoader loader)
         {
-			Clear();
+            Clear();
 
             Entry = entry;
 
@@ -50,38 +50,38 @@ namespace BaseHandlers
             for (int i = 0; i < entry.GetDependencies().Count; i++)
             {
                 Instances.Add(entry.GetDependencies()[i].EntryID);
-			}
+            }
 
-			_scene = MakeScene(loader);
+            _scene = MakeScene(loader);
 
-			return true;
-		}
+            return true;
+        }
 
-		public bool Write(BundleEntry entry)
-		{
-			return true;
-		}
+        public bool Write(BundleEntry entry)
+        {
+            return true;
+        }
 
-		public EntryType GetEntryType(BundleEntry entry)
-		{
-			return EntryType.GraphicsSpec;
-		}
+        public EntryType GetEntryType(BundleEntry entry)
+        {
+            return EntryType.GraphicsSpec;
+        }
 
-		public IEntryEditor GetEditor(BundleEntry entry)
-		{
-			ModelViewerForm viewer = new ModelViewerForm();
-			viewer.Renderer.Scene = _scene;
+        public IEntryEditor GetEditor(BundleEntry entry)
+        {
+            ModelViewerForm viewer = new ModelViewerForm();
+            viewer.Renderer.Scene = _scene;
 
-			return viewer;
-		}
+            return viewer;
+        }
 
-		public Scene MakeScene(ILoader loader)
+        public Scene MakeScene(ILoader loader)
         {
             Scene scene = new Scene();
 
             foreach (uint instance in Instances)
             {
-				BundleEntry modelEntry = Entry.Archive.GetEntryByID(instance);
+                BundleEntry modelEntry = Entry.Archive.GetEntryByID(instance);
                 if (modelEntry == null)
                 {
                     string file = BundleCache.GetFileByEntryID(instance);
@@ -95,8 +95,8 @@ namespace BaseHandlers
                 if (modelEntry != null)
                 {
                     BundleEntry renderableEntry = modelEntry.GetDependencies()[0].Entry;
-					Renderable renderable = new Renderable();
-					renderable.Read(renderableEntry, null); // TODO: Null Loader
+                    Renderable renderable = new Renderable();
+                    renderable.Read(renderableEntry, null); // TODO: Null Loader
                     SceneObject sceneObject = new SceneObject(instance.ToString("X8"), renderable.Model);
                     //sceneObject.Transform = instance.Transform;
 
@@ -106,5 +106,5 @@ namespace BaseHandlers
 
             return scene;
         }
-	}
+    }
 }

--- a/BaseHandlers/IDList.cs
+++ b/BaseHandlers/IDList.cs
@@ -25,30 +25,30 @@ namespace BaseHandlers
             
         }
 
-		public IEntryEditor GetEditor(BundleEntry entry)
-		{
-			return null;
-		}
-
-		public EntryType GetEntryType(BundleEntry entry)
-		{
-			return EntryType.EntryList;
-		}
-
-		private void Clear()
-		{
-			ReferenceEntryIDOffset = default;
-			Unknown2 = default;
-			Unknown3 = default;
-			Unknown4 = default;
-			ReferenceEntryID = default;
-			Unknown6 = default;
-			Unknown7 = default;
-		}
-
-		public bool Read(BundleEntry entry, ILoader loader = null)
+        public IEntryEditor GetEditor(BundleEntry entry)
         {
-			Clear();
+            return null;
+        }
+
+        public EntryType GetEntryType(BundleEntry entry)
+        {
+            return EntryType.EntryList;
+        }
+
+        private void Clear()
+        {
+            ReferenceEntryIDOffset = default;
+            Unknown2 = default;
+            Unknown3 = default;
+            Unknown4 = default;
+            ReferenceEntryID = default;
+            Unknown6 = default;
+            Unknown7 = default;
+        }
+
+        public bool Read(BundleEntry entry, ILoader loader = null)
+        {
+            Clear();
 
             MemoryStream ms = entry.MakeStream();
             BinaryReader2 br = new BinaryReader2(ms);
@@ -65,7 +65,7 @@ namespace BaseHandlers
             br.Close();
             ms.Close();
 
-			return true;
+            return true;
         }
 
         public bool Write(BundleEntry entry)
@@ -91,7 +91,7 @@ namespace BaseHandlers
             entry.EntryBlocks[0].Data = data;
             entry.Dirty = true;
 
-			return true;
+            return true;
         }
     }
 }

--- a/BaseHandlers/InstanceList.cs
+++ b/BaseHandlers/InstanceList.cs
@@ -58,7 +58,7 @@ namespace BaseHandlers
 
     public class InstanceList : IEntryData
     {
-		//private Scene _scene;
+        //private Scene _scene;
 
         public BundleEntry Entry;
 
@@ -74,21 +74,21 @@ namespace BaseHandlers
             Instances = new List<ModelInstance>();
         }
 
-		private void Clear()
-		{
-			//_scene = null;
+        private void Clear()
+        {
+            //_scene = null;
 
-			Entry = default;
-			Unknown1 = default;
-			Unknown2 = default;
-			Unknown3 = default;
+            Entry = default;
+            Unknown1 = default;
+            Unknown2 = default;
+            Unknown3 = default;
 
-			Instances.Clear();
-		}
+            Instances.Clear();
+        }
 
         public bool Read(BundleEntry entry, ILoader loader = null)
         {
-			Clear();
+            Clear();
 
             Entry = entry;
 
@@ -115,9 +115,9 @@ namespace BaseHandlers
             br.Close();
             ms.Close();
 
-			//_scene = MakeScene(loader);
+            //_scene = MakeScene(loader);
 
-			return true;
+            return true;
         }
 
         public bool Write(BundleEntry entry)
@@ -147,7 +147,7 @@ namespace BaseHandlers
             entry.EntryBlocks[0].Data = data;
             entry.Dirty = true;
 
-			return true;
+            return true;
         }
 
         public Scene MakeScene(ILoader loader = null)
@@ -169,10 +169,10 @@ namespace BaseHandlers
                 //DebugTimer t = DebugTimer.Start("ModelInstance[" + index + "/" + Instances.Count + "]");
                 index++;
 
-				if (!InRange(instance))
-					continue;
+                if (!InRange(instance))
+                    continue;
 
-				if (models.ContainsKey(instance.ModelEntryID))
+                if (models.ContainsKey(instance.ModelEntryID))
                 {
                     Renderable renderable = models[instance.ModelEntryID];
                     SceneObject sceneObject = new SceneObject(instance.ModelEntryID.ToString("X8"), renderable.Model);
@@ -183,7 +183,7 @@ namespace BaseHandlers
                 }
                 else
                 {
-					BundleEntry modelEntry = Entry.Archive.GetEntryByID(instance.ModelEntryID);
+                    BundleEntry modelEntry = Entry.Archive.GetEntryByID(instance.ModelEntryID);
                     if (modelEntry == null)
                     {
                         string file = BundleCache.GetFileByEntryID(instance.ModelEntryID);
@@ -197,8 +197,8 @@ namespace BaseHandlers
                     if (modelEntry != null)
                     {
                         BundleEntry renderableEntry = modelEntry.GetDependencies()[0].Entry;
-						Renderable renderable = new Renderable();
-						renderable.Read(renderableEntry, null); // TODO: Null Loader
+                        Renderable renderable = new Renderable();
+                        renderable.Read(renderableEntry, null); // TODO: Null Loader
                         models.Add(instance.ModelEntryID, renderable);
                         SceneObject sceneObject =
                             new SceneObject(instance.ModelEntryID.ToString("X8"), renderable.Model);
@@ -218,26 +218,26 @@ namespace BaseHandlers
             return scene;
         }
 
-		private bool InRange(ModelInstance instance)
-		{
-			return true;
-		}
+        private bool InRange(ModelInstance instance)
+        {
+            return true;
+        }
 
-		public EntryType GetEntryType(BundleEntry entry)
-		{
-			return EntryType.InstanceList;
-		}
+        public EntryType GetEntryType(BundleEntry entry)
+        {
+            return EntryType.InstanceList;
+        }
 
-		public IEntryEditor GetEditor(BundleEntry entry)
-		{
-			InstanceListEditor editor = new InstanceListEditor();
-			editor.InstanceList = this;
-			editor.Changed += () =>
-			{
-				Write(entry);
-			};
+        public IEntryEditor GetEditor(BundleEntry entry)
+        {
+            InstanceListEditor editor = new InstanceListEditor();
+            editor.InstanceList = this;
+            editor.Changed += () =>
+            {
+                Write(entry);
+            };
 
-			return editor;
-		}
-	}
+            return editor;
+        }
+    }
 }

--- a/BaseHandlers/InstanceListEditor.Designer.cs
+++ b/BaseHandlers/InstanceListEditor.Designer.cs
@@ -1,148 +1,148 @@
 ﻿namespace BaseHandlers
 {
-	partial class InstanceListEditor
-	{
-		/// <summary>
-		/// Required designer variable.
-		/// </summary>
-		private System.ComponentModel.IContainer components = null;
+    partial class InstanceListEditor
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
 
-		/// <summary>
-		/// Clean up any resources being used.
-		/// </summary>
-		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-		protected override void Dispose(bool disposing)
-		{
-			if (disposing && (components != null))
-			{
-				components.Dispose();
-			}
-			base.Dispose(disposing);
-		}
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
 
-		#region Windows Form Designer generated code
+        #region Windows Form Designer generated code
 
-		/// <summary>
-		/// Required method for Designer support - do not modify
-		/// the contents of this method with the code editor.
-		/// </summary>
-		private void InitializeComponent()
-		{
-			this.mnuMain = new System.Windows.Forms.MenuStrip();
-			this.debugToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.stsMain = new System.Windows.Forms.StatusStrip();
-			this.renderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.lstMain = new System.Windows.Forms.ListView();
-			this.colModel = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.colTranslation = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.colRotation = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.colScale = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.mnuMain.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// mnuMain
-			// 
-			this.mnuMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.mnuMain = new System.Windows.Forms.MenuStrip();
+            this.debugToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.stsMain = new System.Windows.Forms.StatusStrip();
+            this.renderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.lstMain = new System.Windows.Forms.ListView();
+            this.colModel = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.colTranslation = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.colRotation = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.colScale = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.mnuMain.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // mnuMain
+            // 
+            this.mnuMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.renderToolStripMenuItem,
             this.debugToolStripMenuItem});
-			this.mnuMain.Location = new System.Drawing.Point(0, 0);
-			this.mnuMain.Name = "mnuMain";
-			this.mnuMain.Size = new System.Drawing.Size(800, 24);
-			this.mnuMain.TabIndex = 0;
-			this.mnuMain.Text = "menuStrip1";
-			// 
-			// debugToolStripMenuItem
-			// 
-			this.debugToolStripMenuItem.Name = "debugToolStripMenuItem";
-			this.debugToolStripMenuItem.Size = new System.Drawing.Size(54, 20);
-			this.debugToolStripMenuItem.Text = "Debug";
-			this.debugToolStripMenuItem.Click += new System.EventHandler(this.DebugToolStripMenuItem_Click);
-			// 
-			// stsMain
-			// 
-			this.stsMain.Location = new System.Drawing.Point(0, 428);
-			this.stsMain.Name = "stsMain";
-			this.stsMain.Size = new System.Drawing.Size(800, 22);
-			this.stsMain.TabIndex = 1;
-			this.stsMain.Text = "statusStrip1";
-			// 
-			// renderToolStripMenuItem
-			// 
-			this.renderToolStripMenuItem.Name = "renderToolStripMenuItem";
-			this.renderToolStripMenuItem.Size = new System.Drawing.Size(56, 20);
-			this.renderToolStripMenuItem.Text = "Render";
-			this.renderToolStripMenuItem.Click += new System.EventHandler(this.RenderToolStripMenuItem_Click);
-			// 
-			// lstMain
-			// 
-			this.lstMain.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.mnuMain.Location = new System.Drawing.Point(0, 0);
+            this.mnuMain.Name = "mnuMain";
+            this.mnuMain.Size = new System.Drawing.Size(800, 24);
+            this.mnuMain.TabIndex = 0;
+            this.mnuMain.Text = "menuStrip1";
+            // 
+            // debugToolStripMenuItem
+            // 
+            this.debugToolStripMenuItem.Name = "debugToolStripMenuItem";
+            this.debugToolStripMenuItem.Size = new System.Drawing.Size(54, 20);
+            this.debugToolStripMenuItem.Text = "Debug";
+            this.debugToolStripMenuItem.Click += new System.EventHandler(this.DebugToolStripMenuItem_Click);
+            // 
+            // stsMain
+            // 
+            this.stsMain.Location = new System.Drawing.Point(0, 428);
+            this.stsMain.Name = "stsMain";
+            this.stsMain.Size = new System.Drawing.Size(800, 22);
+            this.stsMain.TabIndex = 1;
+            this.stsMain.Text = "statusStrip1";
+            // 
+            // renderToolStripMenuItem
+            // 
+            this.renderToolStripMenuItem.Name = "renderToolStripMenuItem";
+            this.renderToolStripMenuItem.Size = new System.Drawing.Size(56, 20);
+            this.renderToolStripMenuItem.Text = "Render";
+            this.renderToolStripMenuItem.Click += new System.EventHandler(this.RenderToolStripMenuItem_Click);
+            // 
+            // lstMain
+            // 
+            this.lstMain.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.colModel,
             this.colTranslation,
             this.colRotation,
             this.colScale});
-			this.lstMain.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.lstMain.FullRowSelect = true;
-			this.lstMain.GridLines = true;
-			this.lstMain.HideSelection = false;
-			this.lstMain.Location = new System.Drawing.Point(0, 24);
-			this.lstMain.Name = "lstMain";
-			this.lstMain.Size = new System.Drawing.Size(800, 404);
-			this.lstMain.TabIndex = 2;
-			this.lstMain.UseCompatibleStateImageBehavior = false;
-			this.lstMain.View = System.Windows.Forms.View.Details;
-			this.lstMain.ColumnWidthChanged += new System.Windows.Forms.ColumnWidthChangedEventHandler(this.LstMain_ColumnWidthChanged);
-			this.lstMain.ColumnWidthChanging += new System.Windows.Forms.ColumnWidthChangingEventHandler(this.LstMain_ColumnWidthChanging);
-			this.lstMain.SizeChanged += new System.EventHandler(this.LstMain_SizeChanged);
-			this.lstMain.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.LstMain_MouseDoubleClick);
-			// 
-			// colModel
-			// 
-			this.colModel.Text = "Model";
-			// 
-			// colTranslation
-			// 
-			this.colTranslation.Text = "Position";
-			this.colTranslation.Width = 120;
-			// 
-			// colRotation
-			// 
-			this.colRotation.Text = "Rotation";
-			this.colRotation.Width = 120;
-			// 
-			// colScale
-			// 
-			this.colScale.Text = "Scale";
-			this.colScale.Width = 120;
-			// 
-			// InstanceListEditor
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(800, 450);
-			this.Controls.Add(this.lstMain);
-			this.Controls.Add(this.stsMain);
-			this.Controls.Add(this.mnuMain);
-			this.MainMenuStrip = this.mnuMain;
-			this.Name = "InstanceListEditor";
-			this.Text = "InstanceListEditor";
-			this.Load += new System.EventHandler(this.InstanceListEditor_Load);
-			this.mnuMain.ResumeLayout(false);
-			this.mnuMain.PerformLayout();
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.lstMain.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lstMain.FullRowSelect = true;
+            this.lstMain.GridLines = true;
+            this.lstMain.HideSelection = false;
+            this.lstMain.Location = new System.Drawing.Point(0, 24);
+            this.lstMain.Name = "lstMain";
+            this.lstMain.Size = new System.Drawing.Size(800, 404);
+            this.lstMain.TabIndex = 2;
+            this.lstMain.UseCompatibleStateImageBehavior = false;
+            this.lstMain.View = System.Windows.Forms.View.Details;
+            this.lstMain.ColumnWidthChanged += new System.Windows.Forms.ColumnWidthChangedEventHandler(this.LstMain_ColumnWidthChanged);
+            this.lstMain.ColumnWidthChanging += new System.Windows.Forms.ColumnWidthChangingEventHandler(this.LstMain_ColumnWidthChanging);
+            this.lstMain.SizeChanged += new System.EventHandler(this.LstMain_SizeChanged);
+            this.lstMain.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.LstMain_MouseDoubleClick);
+            // 
+            // colModel
+            // 
+            this.colModel.Text = "Model";
+            // 
+            // colTranslation
+            // 
+            this.colTranslation.Text = "Position";
+            this.colTranslation.Width = 120;
+            // 
+            // colRotation
+            // 
+            this.colRotation.Text = "Rotation";
+            this.colRotation.Width = 120;
+            // 
+            // colScale
+            // 
+            this.colScale.Text = "Scale";
+            this.colScale.Width = 120;
+            // 
+            // InstanceListEditor
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(800, 450);
+            this.Controls.Add(this.lstMain);
+            this.Controls.Add(this.stsMain);
+            this.Controls.Add(this.mnuMain);
+            this.MainMenuStrip = this.mnuMain;
+            this.Name = "InstanceListEditor";
+            this.Text = "InstanceListEditor";
+            this.Load += new System.EventHandler(this.InstanceListEditor_Load);
+            this.mnuMain.ResumeLayout(false);
+            this.mnuMain.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
-		}
+        }
 
-		#endregion
+        #endregion
 
-		private System.Windows.Forms.MenuStrip mnuMain;
-		private System.Windows.Forms.ToolStripMenuItem debugToolStripMenuItem;
-		private System.Windows.Forms.StatusStrip stsMain;
-		private System.Windows.Forms.ToolStripMenuItem renderToolStripMenuItem;
-		private System.Windows.Forms.ListView lstMain;
-		private System.Windows.Forms.ColumnHeader colModel;
-		private System.Windows.Forms.ColumnHeader colTranslation;
-		private System.Windows.Forms.ColumnHeader colRotation;
-		private System.Windows.Forms.ColumnHeader colScale;
-	}
+        private System.Windows.Forms.MenuStrip mnuMain;
+        private System.Windows.Forms.ToolStripMenuItem debugToolStripMenuItem;
+        private System.Windows.Forms.StatusStrip stsMain;
+        private System.Windows.Forms.ToolStripMenuItem renderToolStripMenuItem;
+        private System.Windows.Forms.ListView lstMain;
+        private System.Windows.Forms.ColumnHeader colModel;
+        private System.Windows.Forms.ColumnHeader colTranslation;
+        private System.Windows.Forms.ColumnHeader colRotation;
+        private System.Windows.Forms.ColumnHeader colScale;
+    }
 }

--- a/BaseHandlers/InstanceListEditor.cs
+++ b/BaseHandlers/InstanceListEditor.cs
@@ -17,252 +17,252 @@ using System.Windows.Forms;
 
 namespace BaseHandlers
 {
-	public partial class InstanceListEditor : Form, IEntryEditor
-	{
-		public delegate void OnChanged();
-		public event OnChanged Changed;
+    public partial class InstanceListEditor : Form, IEntryEditor
+    {
+        public delegate void OnChanged();
+        public event OnChanged Changed;
 
-		private InstanceList _instanceList;
+        private InstanceList _instanceList;
 
-		public InstanceList InstanceList
-		{
-			get => _instanceList;
-			set
-			{
-				_instanceList = value;
-				UpdateDisplay();
-			}
-		}
+        public InstanceList InstanceList
+        {
+            get => _instanceList;
+            set
+            {
+                _instanceList = value;
+                UpdateDisplay();
+            }
+        }
 
-		private Dictionary<ulong, string> _nameCache;
+        private Dictionary<ulong, string> _nameCache;
 
-		public InstanceListEditor()
-		{
-			InitializeComponent();
+        public InstanceListEditor()
+        {
+            InitializeComponent();
 
-			_nameCache = new Dictionary<ulong, string>();
-		}
+            _nameCache = new Dictionary<ulong, string>();
+        }
 
-		private void UpdateDisplay()
-		{
-			lstMain.Items.Clear();
+        private void UpdateDisplay()
+        {
+            lstMain.Items.Clear();
 
-			if (InstanceList == null)
-				return;
+            if (InstanceList == null)
+                return;
 
-			for (int i = 0; i < InstanceList.Instances.Count; i++)
-			{
-				ModelInstance model = InstanceList.Instances[i];
+            for (int i = 0; i < InstanceList.Instances.Count; i++)
+            {
+                ModelInstance model = InstanceList.Instances[i];
 
-				string[] items = new string[]
-				{
-					GetModelName(model.ModelEntryID),
-					model.Translation.ToString(),
-					model.Rotation.ToString(),
-					model.Scale.ToString()
-				};
+                string[] items = new string[]
+                {
+                    GetModelName(model.ModelEntryID),
+                    model.Translation.ToString(),
+                    model.Rotation.ToString(),
+                    model.Scale.ToString()
+                };
 
-				lstMain.Items.Add(new ListViewItem(items));
-			}
-		}
+                lstMain.Items.Add(new ListViewItem(items));
+            }
+        }
 
-		private void UpdateColumnWidth()
-		{
-			if (lstMain.Columns.Count <= 0)
-				return;
+        private void UpdateColumnWidth()
+        {
+            if (lstMain.Columns.Count <= 0)
+                return;
 
-			int totalColumnWidth = 0;
-			for (int i = 1; i < lstMain.Columns.Count; i++)
-			{
-				totalColumnWidth += lstMain.Columns[i].Width;
-			}
+            int totalColumnWidth = 0;
+            for (int i = 1; i < lstMain.Columns.Count; i++)
+            {
+                totalColumnWidth += lstMain.Columns[i].Width;
+            }
 
-			int remainingWidth = lstMain.Width - totalColumnWidth - 120;
+            int remainingWidth = lstMain.Width - totalColumnWidth - 120;
 
-			if (lstMain.Columns[0].Width != remainingWidth)
-				lstMain.Columns[0].Width = remainingWidth;
-		}
+            if (lstMain.Columns[0].Width != remainingWidth)
+                lstMain.Columns[0].Width = remainingWidth;
+        }
 
-		private string GetModelName(ulong id)
-		{
-			if (_nameCache.ContainsKey(id))
-				return _nameCache[id];
+        private string GetModelName(ulong id)
+        {
+            if (_nameCache.ContainsKey(id))
+                return _nameCache[id];
 
-			string result;
+            string result;
 
-			//BundleArchive archive = InstanceList.Entry.Archive;
-			//bool external = !archive.ContainsEntry(id);
-			//if (external)
-				result = BundleCache.GetEntryNameByID(id);
-			//else
-			//	result = archive.GetEntryNameByID(id);
+            //BundleArchive archive = InstanceList.Entry.Archive;
+            //bool external = !archive.ContainsEntry(id);
+            //if (external)
+                result = BundleCache.GetEntryNameByID(id);
+            //else
+            //    result = archive.GetEntryNameByID(id);
 
-			if (string.IsNullOrWhiteSpace(result))
-				result = "0x" + id.ToString("X8");
-			else
-				result = SimplifyModelName(result);
+            if (string.IsNullOrWhiteSpace(result))
+                result = "0x" + id.ToString("X8");
+            else
+                result = SimplifyModelName(result);
 
-			//if (external)
-			//	result += " (External)";
+            //if (external)
+            //    result += " (External)";
 
-			_nameCache.Add(id, result);
-			return result;
-		}
+            _nameCache.Add(id, result);
+            return result;
+        }
 
-		private string SimplifyModelName(string name)
-		{
-			string commonstring = "gamedb://burnout5/";
-			if (name.StartsWith(commonstring))
-				name = name.Substring(commonstring.Length);
+        private string SimplifyModelName(string name)
+        {
+            string commonstring = "gamedb://burnout5/";
+            if (name.StartsWith(commonstring))
+                name = name.Substring(commonstring.Length);
 
-			commonstring = "Burnout/Content_World/";
-			if (name.StartsWith(commonstring))
-				name = name.Substring(commonstring.Length);
+            commonstring = "Burnout/Content_World/";
+            if (name.StartsWith(commonstring))
+                name = name.Substring(commonstring.Length);
 
-			/*commonstring = "Scenes/";
-			if (name.StartsWith(commonstring))
-				name = name.Substring(commonstring.Length);
+            /*commonstring = "Scenes/";
+            if (name.StartsWith(commonstring))
+                name = name.Substring(commonstring.Length);
 
-			commonstring = "Scenes_Final/";
-			if (name.StartsWith(commonstring))
-				name = name.Substring(commonstring.Length);*/
+            commonstring = "Scenes_Final/";
+            if (name.StartsWith(commonstring))
+                name = name.Substring(commonstring.Length);*/
 
-			int qIndex = name.IndexOf("?");
-			if (qIndex > -1)
-				name = name.Substring(0, qIndex);
-			return name;
-		}
+            int qIndex = name.IndexOf("?");
+            if (qIndex > -1)
+                name = name.Substring(0, qIndex);
+            return name;
+        }
 
-		private void ViewSelectedModel()
-		{
-			if (lstMain.SelectedIndices.Count <= 0)
-				return;
+        private void ViewSelectedModel()
+        {
+            if (lstMain.SelectedIndices.Count <= 0)
+                return;
 
-			int selectedIndex = lstMain.SelectedIndices[0];
-			ModelInstance model = InstanceList.Instances[selectedIndex];
+            int selectedIndex = lstMain.SelectedIndices[0];
+            ModelInstance model = InstanceList.Instances[selectedIndex];
 
-			LoadingDialog loader = new LoadingDialog();
-			BundleEntry renderableEntry = null;
-			Renderable renderable = null;
+            LoadingDialog loader = new LoadingDialog();
+            BundleEntry renderableEntry = null;
+            Renderable renderable = null;
 
-			Thread loadInstanceThread = null;
-			bool failure = false;
+            Thread loadInstanceThread = null;
+            bool failure = false;
 
-			loader.Done += (cancelled, value) =>
-			{
-				if (cancelled)
-					loadInstanceThread?.Abort();
-				else
-				{
-					loader.Hide();
-					if (!failure)
-					{
-						IEntryEditor editor = renderable.GetEditor(renderableEntry);
-						editor.ShowDialog(this);
-					}
-				}
-			};
+            loader.Done += (cancelled, value) =>
+            {
+                if (cancelled)
+                    loadInstanceThread?.Abort();
+                else
+                {
+                    loader.Hide();
+                    if (!failure)
+                    {
+                        IEntryEditor editor = renderable.GetEditor(renderableEntry);
+                        editor.ShowDialog(this);
+                    }
+                }
+            };
 
-			loadInstanceThread = new Thread(() =>
-			{
-				try
-				{
-					BundleEntry modelEntry = InstanceList.Entry.Archive.GetEntryByID(model.ModelEntryID);
-					if (modelEntry == null)
-					{
-						string file = BundleCache.GetFileByEntryID(model.ModelEntryID);
-						if (!string.IsNullOrEmpty(file))
-						{
-							BundleArchive archive = BundleArchive.Read(file);
-							modelEntry = archive.GetEntryByID(model.ModelEntryID);
-						}
-					}
+            loadInstanceThread = new Thread(() =>
+            {
+                try
+                {
+                    BundleEntry modelEntry = InstanceList.Entry.Archive.GetEntryByID(model.ModelEntryID);
+                    if (modelEntry == null)
+                    {
+                        string file = BundleCache.GetFileByEntryID(model.ModelEntryID);
+                        if (!string.IsNullOrEmpty(file))
+                        {
+                            BundleArchive archive = BundleArchive.Read(file);
+                            modelEntry = archive.GetEntryByID(model.ModelEntryID);
+                        }
+                    }
 
-					if (modelEntry != null)
-					{
-						renderableEntry = modelEntry.GetDependencies()[0].Entry;
-						renderable = new Renderable();
-						renderable.Read(renderableEntry, loader);
-					}
-					if (renderable == null)
-						failure = true;
-				}
-				catch (Exception)
-				{
-					failure = true;
-				}
-				loader.IsDone = true;
-			});
-			loadInstanceThread.Start();
-			loader.ShowDialog(this);
-		}
+                    if (modelEntry != null)
+                    {
+                        renderableEntry = modelEntry.GetDependencies()[0].Entry;
+                        renderable = new Renderable();
+                        renderable.Read(renderableEntry, loader);
+                    }
+                    if (renderable == null)
+                        failure = true;
+                }
+                catch (Exception)
+                {
+                    failure = true;
+                }
+                loader.IsDone = true;
+            });
+            loadInstanceThread.Start();
+            loader.ShowDialog(this);
+        }
 
-		private void InstanceListEditor_Load(object sender, EventArgs e)
-		{
-			UpdateColumnWidth();
-		}
+        private void InstanceListEditor_Load(object sender, EventArgs e)
+        {
+            UpdateColumnWidth();
+        }
 
-		private void RenderToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			LoadingDialog loader = new LoadingDialog();
-			Scene scene = null;
+        private void RenderToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            LoadingDialog loader = new LoadingDialog();
+            Scene scene = null;
 
-			Thread loadInstanceThread = null;
-			bool failure = false;
+            Thread loadInstanceThread = null;
+            bool failure = false;
 
-			loader.Done += (cancelled, value) =>
-			{
-				if (cancelled)
-					loadInstanceThread?.Abort();
-				else
-				{
-					loader.Hide();
-					if (!failure)
-						ModelViewerForm.ShowModelViewer(this, scene);
-				}
-			};
+            loader.Done += (cancelled, value) =>
+            {
+                if (cancelled)
+                    loadInstanceThread?.Abort();
+                else
+                {
+                    loader.Hide();
+                    if (!failure)
+                        ModelViewerForm.ShowModelViewer(this, scene);
+                }
+            };
 
-			loadInstanceThread = new Thread(() =>
-			{
-				try
-				{
-					scene = InstanceList.MakeScene(loader);
-					if (scene == null)
-						failure = true;
-				}
-				catch (Exception)
-				{
-					failure = true;
-				}
-				loader.IsDone = true;
-			});
-			loadInstanceThread.Start();
-			loader.ShowDialog(this);
-		}
+            loadInstanceThread = new Thread(() =>
+            {
+                try
+                {
+                    scene = InstanceList.MakeScene(loader);
+                    if (scene == null)
+                        failure = true;
+                }
+                catch (Exception)
+                {
+                    failure = true;
+                }
+                loader.IsDone = true;
+            });
+            loadInstanceThread.Start();
+            loader.ShowDialog(this);
+        }
 
-		private void DebugToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			DebugUtil.ShowDebug(this, InstanceList);
-		}
+        private void DebugToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            DebugUtil.ShowDebug(this, InstanceList);
+        }
 
-		private void LstMain_SizeChanged(object sender, EventArgs e)
-		{
-			UpdateColumnWidth();
-		}
+        private void LstMain_SizeChanged(object sender, EventArgs e)
+        {
+            UpdateColumnWidth();
+        }
 
-		private void LstMain_MouseDoubleClick(object sender, MouseEventArgs e)
-		{
-			ViewSelectedModel();
-		}
+        private void LstMain_MouseDoubleClick(object sender, MouseEventArgs e)
+        {
+            ViewSelectedModel();
+        }
 
-		private void LstMain_ColumnWidthChanging(object sender, ColumnWidthChangingEventArgs e)
-		{
-			//e.Cancel = true;
-		}
+        private void LstMain_ColumnWidthChanging(object sender, ColumnWidthChangingEventArgs e)
+        {
+            //e.Cancel = true;
+        }
 
-		private void LstMain_ColumnWidthChanged(object sender, ColumnWidthChangedEventArgs e)
-		{
-			//UpdateColumnWidth();
-		}
-	}
+        private void LstMain_ColumnWidthChanged(object sender, ColumnWidthChangedEventArgs e)
+        {
+            //UpdateColumnWidth();
+        }
+    }
 }

--- a/BaseHandlers/MaterialEntry.cs
+++ b/BaseHandlers/MaterialEntry.cs
@@ -33,8 +33,8 @@ namespace BaseHandlers
             {
                 ulong id = dependency.EntryID;
 
-				//DebugTimer t = DebugTimer.Start("LoadDep");
-				BundleEntry descEntry1 = entry.Archive.GetEntryByID(id);
+                //DebugTimer t = DebugTimer.Start("LoadDep");
+                BundleEntry descEntry1 = entry.Archive.GetEntryByID(id);
                 if (descEntry1 == null)
                 {
                     string file = BundleCache.GetFileByEntryID(id);
@@ -42,7 +42,7 @@ namespace BaseHandlers
                     {
                         BundleArchive archive = BundleArchive.Read(file);
                         descEntry1 = archive.GetEntryByID(id);
-					}
+                    }
                 }
                 //t.StopLog();
 

--- a/BaseHandlers/ProgressionData.cs
+++ b/BaseHandlers/ProgressionData.cs
@@ -266,24 +266,24 @@ namespace BaseHandlers
             PlayerOpponentsDataEntries = new List<PlayerOpponentsData>();
         }
 
-		public IEntryEditor GetEditor(BundleEntry entry)
-		{
-			return null;
-		}
-
-		public EntryType GetEntryType(BundleEntry entry)
-		{
-			return EntryType.ProgressionData;
-		}
-
-		private void Clear()
-		{
-
-		}
-
-		public bool Read(BundleEntry entry, ILoader loader = null)
+        public IEntryEditor GetEditor(BundleEntry entry)
         {
-			Clear();
+            return null;
+        }
+
+        public EntryType GetEntryType(BundleEntry entry)
+        {
+            return EntryType.ProgressionData;
+        }
+
+        private void Clear()
+        {
+
+        }
+
+        public bool Read(BundleEntry entry, ILoader loader = null)
+        {
+            Clear();
 
             MemoryStream ms = entry.MakeStream();
             BinaryReader2 br = new BinaryReader2(ms);
@@ -615,7 +615,7 @@ namespace BaseHandlers
             entry.EntryBlocks[0].Data = data;
             entry.Dirty = true;
 
-			return true;
+            return true;
         }
     }
 }

--- a/BaseHandlers/Renderable.cs
+++ b/BaseHandlers/Renderable.cs
@@ -58,9 +58,9 @@ namespace BaseHandlers
     {
         public static bool LoadMaterials => Config.LoadMaterials;
 
-		private Scene _scene;
+        private Scene _scene;
 
-		public float Unknown1;
+        public float Unknown1;
         public float Unknown2;
         public float Unknown3;
         public float Unknown4;
@@ -236,59 +236,59 @@ namespace BaseHandlers
                     }
                 }
 
-				if (attributeToUse.Size == 0)
-				{
-					break;
-				}
+                if (attributeToUse.Size == 0)
+                {
+                    break;
+                }
 
-				mesh.Vertices = new List<VertexData>();
+                mesh.Vertices = new List<VertexData>();
                 br.BaseStream.Position = VertexBlockAddress + mesh.VertexOffsetCount * attributeToUse.Size + attributeToUse.Offset;
-				while (br.BaseStream.Position + attributeToUse.Size < br.BaseStream.Length) // Really, this should not be done like this.
+                while (br.BaseStream.Position + attributeToUse.Size < br.BaseStream.Length) // Really, this should not be done like this.
                 {
                     mesh.Vertices.Add(ReadVertex(br, attributeToUse));
                 }
-			}
+            }
         }
 
-		private void Clear()
-		{
-			_scene = null;
+        private void Clear()
+        {
+            _scene = null;
 
-			Unknown1 = default;
-			Unknown2 = default;
-			Unknown3 = default;
-			Unknown4 = default;
-			Unknown5 = default;
-			MeshCount = default;
+            Unknown1 = default;
+            Unknown2 = default;
+            Unknown3 = default;
+            Unknown4 = default;
+            Unknown5 = default;
+            MeshCount = default;
 
-			StartOffset = default;
-			Unknown8 = default;
-			Unknown9 = default;
-			Unknown10 = default;
-			Unknown10_1 = default;
-			UnknownOffset = default;
-			Unknown12 = default;
-			Unknown13 = default;
+            StartOffset = default;
+            Unknown8 = default;
+            Unknown9 = default;
+            Unknown10 = default;
+            Unknown10_1 = default;
+            UnknownOffset = default;
+            Unknown12 = default;
+            Unknown13 = default;
 
-			NumIndices = default;
-			Unknown15 = default;
-			Unknown16 = default;
-			Unknown17 = default;
-			VertexBlockAddress = default;
-			Unknown18 = default;
-			VertexBlockSize = default;
+            NumIndices = default;
+            Unknown15 = default;
+            Unknown16 = default;
+            Unknown17 = default;
+            VertexBlockAddress = default;
+            Unknown18 = default;
+            VertexBlockSize = default;
 
-			ID = default;
-			Model = default;
+            ID = default;
+            Model = default;
 
-			MeshVertexOffsets.Clear();
-			Meshes.Clear();
-			Indices.Clear();
-		}
+            MeshVertexOffsets.Clear();
+            Meshes.Clear();
+            Indices.Clear();
+        }
 
         public bool Read(BundleEntry entry, ILoader loader)
         {
-			Clear();
+            Clear();
 
             List<BundleDependency> dependencies = entry.GetDependencies();
 
@@ -407,19 +407,19 @@ namespace BaseHandlers
             br.Close();
             ms.Close();
             
-			loader?.SetStatus("Loading Meshes");
+            loader?.SetStatus("Loading Meshes");
             for (int i = 0; i < Meshes.Count; i++)
             {
                 RenderableMesh mesh = Meshes[i];
 
-				int progress = (i + 1) * 100 / Meshes.Count;
+                int progress = (i + 1) * 100 / Meshes.Count;
 
-				loader?.SetStatus("Loading Meshes: " + (i + 1) + "/" + Meshes.Count);
-				loader?.SetProgress(progress);
+                loader?.SetStatus("Loading Meshes: " + (i + 1) + "/" + Meshes.Count);
+                loader?.SetProgress(progress);
 
                 if (LoadMaterials)
                 {
-					BundleEntry descEntry1 = entry.Archive.GetEntryByID(mesh.MaterialID);
+                    BundleEntry descEntry1 = entry.Archive.GetEntryByID(mesh.MaterialID);
                     if (descEntry1 == null)
                     {
                         string file = BundleCache.GetFileByEntryID(mesh.MaterialID);
@@ -427,7 +427,7 @@ namespace BaseHandlers
                         {
                             BundleArchive archive = BundleArchive.Read(file);
                             descEntry1 = archive.GetEntryByID(mesh.MaterialID);
-						}
+                        }
                     }
 
                     if (descEntry1 != null)
@@ -438,7 +438,7 @@ namespace BaseHandlers
                 for (int j = 0; j < mesh.VertexDescriptions.Length; j++)
                 {
                     ulong vertexDescID = mesh.VertexDescriptionIDs[j];
-					BundleEntry descEntry = entry.Archive.GetEntryByID(vertexDescID);
+                    BundleEntry descEntry = entry.Archive.GetEntryByID(vertexDescID);
                     if (descEntry == null)
                     {
                         string file = BundleCache.GetFileByEntryID(vertexDescID);
@@ -463,36 +463,36 @@ namespace BaseHandlers
 
             BuildModel();
 
-			_scene = MakeScene(loader);
+            _scene = MakeScene(loader);
 
-			return true;
+            return true;
         }
 
-		public bool Write(BundleEntry entry)
-		{
-			return true;
-		}
+        public bool Write(BundleEntry entry)
+        {
+            return true;
+        }
 
-		public EntryType GetEntryType(BundleEntry entry)
-		{
-			return EntryType.Renderable;
-		}
+        public EntryType GetEntryType(BundleEntry entry)
+        {
+            return EntryType.Renderable;
+        }
 
-		public IEntryEditor GetEditor(BundleEntry entry)
-		{
-			ModelViewerForm viewer = new ModelViewerForm();
-			viewer.Renderer.Scene = _scene;
+        public IEntryEditor GetEditor(BundleEntry entry)
+        {
+            ModelViewerForm viewer = new ModelViewerForm();
+            viewer.Renderer.Scene = _scene;
 
-			return viewer;
-		}
+            return viewer;
+        }
 
-		public Scene MakeScene(ILoader loader = null)
-		{
-			Scene scene = new Scene();
-			SceneObject obj = new SceneObject(ID.ToString("X8"), Model);
-			scene.AddObject(obj);
+        public Scene MakeScene(ILoader loader = null)
+        {
+            Scene scene = new Scene();
+            SceneObject obj = new SceneObject(ID.ToString("X8"), Model);
+            scene.AddObject(obj);
 
-			return scene;
-		}
-	}
+            return scene;
+        }
+    }
 }

--- a/BaseHandlers/StreetData.cs
+++ b/BaseHandlers/StreetData.cs
@@ -123,31 +123,31 @@ namespace BaseHandlers
             StreetSection5s = new List<StreetSection5>();
         }
 
-		private void Clear()
-		{
-			Unknown1 = default;
-			FileSize = default;
-			Unknown3 = default;
-			Section2Offset = default;
-			StreetOffset = default;
-			RoadRuleOffset = default;
-			Section1Count = default;
-			RoadRuleCount = default;
-			StreetCount = default;
-			Unknown9 = default;
-			Unknown10 = default;
-			Unknown11 = default;
+        private void Clear()
+        {
+            Unknown1 = default;
+            FileSize = default;
+            Unknown3 = default;
+            Section2Offset = default;
+            StreetOffset = default;
+            RoadRuleOffset = default;
+            Section1Count = default;
+            RoadRuleCount = default;
+            StreetCount = default;
+            Unknown9 = default;
+            Unknown10 = default;
+            Unknown11 = default;
 
-			StreetSection1s.Clear();
-			StreetSection2s.Clear();
-			StreetInfos.Clear();
-			RoadRuleInfos.Clear();
-			StreetSection5s.Clear();
-		}
+            StreetSection1s.Clear();
+            StreetSection2s.Clear();
+            StreetInfos.Clear();
+            RoadRuleInfos.Clear();
+            StreetSection5s.Clear();
+        }
 
         public bool Read(BundleEntry entry, ILoader loader = null)
         {
-			Clear();
+            Clear();
 
             MemoryStream ms = entry.MakeStream();
             BinaryReader2 br = new BinaryReader2(ms);
@@ -392,17 +392,17 @@ namespace BaseHandlers
             entry.EntryBlocks[0].Data = data;
             entry.Dirty = true;
 
-			return true;
+            return true;
         }
 
-		public EntryType GetEntryType(BundleEntry entry)
-		{
-			return EntryType.StreetData;
-		}
+        public EntryType GetEntryType(BundleEntry entry)
+        {
+            return EntryType.StreetData;
+        }
 
-		public IEntryEditor GetEditor(BundleEntry entry)
-		{
-			return null;
-		}
-	}
+        public IEntryEditor GetEditor(BundleEntry entry)
+        {
+            return null;
+        }
+    }
 }

--- a/BaseHandlers/TextureState.cs
+++ b/BaseHandlers/TextureState.cs
@@ -35,7 +35,7 @@ namespace BaseHandlers
                 }
                 else
                 {
-					BundleEntry descEntry1 = entry.Archive.GetEntryByID(id);
+                    BundleEntry descEntry1 = entry.Archive.GetEntryByID(id);
                     if (descEntry1 == null)
                     {
                         string file = BundleCache.GetFileByEntryID(id);
@@ -51,11 +51,11 @@ namespace BaseHandlers
                     {
                         if (entry.Console)
                             result.Texture = GameImage.GetImagePS3(descEntry1.EntryBlocks[0].Data, descEntry1.EntryBlocks[1].Data);
-						else
+                        else
                             result.Texture = GameImage.GetImage(descEntry1.EntryBlocks[0].Data, descEntry1.EntryBlocks[1].Data);
 
-						if (result.Texture != null)
-							TextureCache.AddToCache(id, result.Texture);
+                        if (result.Texture != null)
+                            TextureCache.AddToCache(id, result.Texture);
 
                         break;
                     }

--- a/BaseHandlers/Traffic.cs
+++ b/BaseHandlers/Traffic.cs
@@ -51,56 +51,56 @@ namespace BaseHandlers
             UnknownShorts = new List<short>();
         }
 
-		public IEntryEditor GetEditor(BundleEntry entry)
-		{
-			return null;
-		}
-
-		public EntryType GetEntryType(BundleEntry entry)
-		{
-			return EntryType.TrafficData;
-		}
-
-		private void Clear()
-		{
-			Unknown1 = default;
-			Unknown2 = default;
-			FileSize = default;
-			TrackCount = default;
-			Unknown3 = default;
-			PointerOffset = default;
-			Unknown4 = default;
-			Unknown5 = default;
-			Unknown6 = default;
-			Unknown7 = default;
-			Unknown8 = default;
-			Unknown9 = default;
-			Unknown10 = default;
-			Section1Offset = default;
-			Section2Offset = default;
-			Section3Offset = default;
-			Section4Offset = default;
-			Section5Offset = default;
-			Section6Offset = default;
-			Section7Offset = default;
-			Section8Offset = default;
-			Unknown11 = default;
-			Unknown12 = default;
-			Unknown13 = default;
-			UnknownOffset1 = default;
-			UnknownOffset2 = default;
-			UnknownOffset3 = default;
-			UnknownOffset4 = default;
-			UnknownOffset5 = default;
-			Unknown14 = default;
-			Unknown15 = default;
-
-			UnknownShorts.Clear();
-		}
-
-		public bool Read(BundleEntry entry, ILoader loader = null)
+        public IEntryEditor GetEditor(BundleEntry entry)
         {
-			Clear();
+            return null;
+        }
+
+        public EntryType GetEntryType(BundleEntry entry)
+        {
+            return EntryType.TrafficData;
+        }
+
+        private void Clear()
+        {
+            Unknown1 = default;
+            Unknown2 = default;
+            FileSize = default;
+            TrackCount = default;
+            Unknown3 = default;
+            PointerOffset = default;
+            Unknown4 = default;
+            Unknown5 = default;
+            Unknown6 = default;
+            Unknown7 = default;
+            Unknown8 = default;
+            Unknown9 = default;
+            Unknown10 = default;
+            Section1Offset = default;
+            Section2Offset = default;
+            Section3Offset = default;
+            Section4Offset = default;
+            Section5Offset = default;
+            Section6Offset = default;
+            Section7Offset = default;
+            Section8Offset = default;
+            Unknown11 = default;
+            Unknown12 = default;
+            Unknown13 = default;
+            UnknownOffset1 = default;
+            UnknownOffset2 = default;
+            UnknownOffset3 = default;
+            UnknownOffset4 = default;
+            UnknownOffset5 = default;
+            Unknown14 = default;
+            Unknown15 = default;
+
+            UnknownShorts.Clear();
+        }
+
+        public bool Read(BundleEntry entry, ILoader loader = null)
+        {
+            Clear();
 
             MemoryStream ms = entry.MakeStream();
             BinaryReader2 br = new BinaryReader2(ms);
@@ -151,7 +151,7 @@ namespace BaseHandlers
 
         public bool Write(BundleEntry entry)
         {
-			return true;
+            return true;
         }
     }
 }

--- a/BaseHandlers/TriggerData.cs
+++ b/BaseHandlers/TriggerData.cs
@@ -154,51 +154,51 @@ namespace BaseHandlers
             TriggerOffsets = new List<uint>();
         }
 
-		private void Clear()
-		{
-			FormatRevision = default;
-			FileSize = default;
-			Unknown0C = default;
-			Unknown10 = default;
-			DevSpawnPositionX = default;
-			DevSpawnPositionY = default;
-			DevSpawnPositionZ = default;
-			DevSpawnUnknownHash = default;
-			DevSpawnRotationX = default;
-			DevSpawnRotationY = default;
-			DevSpawnRotationZ = default;
-			DevSpawnUnknownFloat = default;
-			LandmarkTriggersOffset = default;
-			LandmarkTriggersCount = default;
-			LandmarkNonFinishLineCount = default;
-			BlackspotTriggersOffset = default;
-			BlackspotTriggersCount = default;
-			GenericRegionTriggersOffset = default;
-			GenericRegionTriggersCount = default;
-			Section4Offset = default;
-			Section4Count = default;
-			VFXBoxRegionOffset = default;
-			VFXBoxRegionCount = default;
-			StartPositionsOffset = default;
-			StartPositionsCount = default;
-			RoamingLocationsOffset = default;
-			RoamingLocationsCount = default;
-			SpawnLocationsOffset = default;
-			SpawnLocationsCount = default;
-			TriggerOffsetListOffset = default;
-			TriggerOffsetListCount = default;
+        private void Clear()
+        {
+            FormatRevision = default;
+            FileSize = default;
+            Unknown0C = default;
+            Unknown10 = default;
+            DevSpawnPositionX = default;
+            DevSpawnPositionY = default;
+            DevSpawnPositionZ = default;
+            DevSpawnUnknownHash = default;
+            DevSpawnRotationX = default;
+            DevSpawnRotationY = default;
+            DevSpawnRotationZ = default;
+            DevSpawnUnknownFloat = default;
+            LandmarkTriggersOffset = default;
+            LandmarkTriggersCount = default;
+            LandmarkNonFinishLineCount = default;
+            BlackspotTriggersOffset = default;
+            BlackspotTriggersCount = default;
+            GenericRegionTriggersOffset = default;
+            GenericRegionTriggersCount = default;
+            Section4Offset = default;
+            Section4Count = default;
+            VFXBoxRegionOffset = default;
+            VFXBoxRegionCount = default;
+            StartPositionsOffset = default;
+            StartPositionsCount = default;
+            RoamingLocationsOffset = default;
+            RoamingLocationsCount = default;
+            SpawnLocationsOffset = default;
+            SpawnLocationsCount = default;
+            TriggerOffsetListOffset = default;
+            TriggerOffsetListCount = default;
 
-			LandmarkTriggers.Clear();
-			GenericRegionTriggers.Clear();
-			Section4Entries.Clear();
-			RoamingLocationEntries.Clear();
-			SpawnLocationEntries.Clear();
-			TriggerOffsets.Clear();
-		}
+            LandmarkTriggers.Clear();
+            GenericRegionTriggers.Clear();
+            Section4Entries.Clear();
+            RoamingLocationEntries.Clear();
+            SpawnLocationEntries.Clear();
+            TriggerOffsets.Clear();
+        }
 
         public bool Read(BundleEntry entry, ILoader loader = null)
         {
-			Clear();
+            Clear();
 
             MemoryStream ms = entry.MakeStream();
             BinaryReader2 br = new BinaryReader2(ms);
@@ -394,20 +394,20 @@ namespace BaseHandlers
             br.Close();
             ms.Close();
 
-			return true;
+            return true;
         }
 
-		public IEntryEditor GetEditor(BundleEntry entry)
-		{
-			return null;
-		}
+        public IEntryEditor GetEditor(BundleEntry entry)
+        {
+            return null;
+        }
 
-		public EntryType GetEntryType(BundleEntry entry)
-		{
-			return EntryType.TriggerData;
-		}
+        public EntryType GetEntryType(BundleEntry entry)
+        {
+            return EntryType.TriggerData;
+        }
 
-		public bool Write(BundleEntry entry)
+        public bool Write(BundleEntry entry)
         {
             MemoryStream ms = new MemoryStream();
             BinaryWriter bw = new BinaryWriter(ms);
@@ -578,7 +578,7 @@ namespace BaseHandlers
             entry.EntryBlocks[0].Data = data;
             entry.Dirty = true;
 
-			return true;
+            return true;
         }
-	}
+    }
 }

--- a/BundleFormat/BundleArchive.cs
+++ b/BundleFormat/BundleArchive.cs
@@ -32,11 +32,11 @@ namespace BundleFormat
 
     public class BundleArchive
     {
-		public static readonly byte[] BND1Magic = new byte[] { 0x62, 0x6E, 0x64, 0x6C };
+        public static readonly byte[] BND1Magic = new byte[] { 0x62, 0x6E, 0x64, 0x6C };
         public static readonly byte[] BND2Magic = new byte[] { 0x62, 0x6E, 0x64, 0x32 };
 
-		public string Path;
-		public int BNDVersion;
+        public string Path;
+        public int BNDVersion;
 
         public int Version;
         public BundlePlatform Platform;
@@ -96,74 +96,74 @@ namespace BundleFormat
             return null;
         }
 
-		public string GetEntryNameByID(ulong id)
-		{
-			for (int i = 0; i < Entries.Count; i++)
-			{
-				BundleEntry entry = Entries[i];
-				if (entry.ID == id)
-					return entry.DetectName();
-			}
-			return null;
-		}
+        public string GetEntryNameByID(ulong id)
+        {
+            for (int i = 0; i < Entries.Count; i++)
+            {
+                BundleEntry entry = Entries[i];
+                if (entry.ID == id)
+                    return entry.DetectName();
+            }
+            return null;
+        }
 
-		public bool ContainsEntry(ulong id)
-		{
-			return GetEntryByID(id) != null;
-		}
+        public bool ContainsEntry(ulong id)
+        {
+            return GetEntryByID(id) != null;
+        }
 
-		private static Dictionary<ulong, DebugInfo> GetDebugInfoFromRST(string rst)
-		{
-			XmlDocument doc = new XmlDocument();
-			doc.LoadXml(rst);
+        private static Dictionary<ulong, DebugInfo> GetDebugInfoFromRST(string rst)
+        {
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml(rst);
 
-			XmlElement root = doc["ResourceStringTable"];
-			XmlNodeList resources = root.GetElementsByTagName("Resource");
+            XmlElement root = doc["ResourceStringTable"];
+            XmlNodeList resources = root.GetElementsByTagName("Resource");
 
-			Dictionary<ulong, DebugInfo> debugInfo = new Dictionary<ulong, DebugInfo>();
+            Dictionary<ulong, DebugInfo> debugInfo = new Dictionary<ulong, DebugInfo>();
 
-			foreach (XmlElement ele in resources)
-			{
-				if (ele.Name != "Resource")
-					continue;
+            foreach (XmlElement ele in resources)
+            {
+                if (ele.Name != "Resource")
+                    continue;
 
-				if (!ulong.TryParse(ele.Attributes["id"].Value, NumberStyles.AllowHexSpecifier, CultureInfo.CurrentCulture, out ulong resourceID))
-					continue;
+                if (!ulong.TryParse(ele.Attributes["id"].Value, NumberStyles.AllowHexSpecifier, CultureInfo.CurrentCulture, out ulong resourceID))
+                    continue;
 
-				DebugInfo debug;
-				debug.Name = ele.Attributes["name"].Value;
-				debug.TypeName = ele.Attributes["type"].Value;
+                DebugInfo debug;
+                debug.Name = ele.Attributes["name"].Value;
+                debug.TypeName = ele.Attributes["type"].Value;
 
-				debugInfo.Add(resourceID, debug);
-			}
+                debugInfo.Add(resourceID, debug);
+            }
 
-			return debugInfo;
-		}
+            return debugInfo;
+        }
 
-		private void ProcessRST(string rst)
-		{
-			XmlDocument doc = new XmlDocument();
-			doc.LoadXml(rst);
+        private void ProcessRST(string rst)
+        {
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml(rst);
 
-			XmlElement root = doc["ResourceStringTable"];
-			XmlNodeList resources = root.GetElementsByTagName("Resource");
+            XmlElement root = doc["ResourceStringTable"];
+            XmlNodeList resources = root.GetElementsByTagName("Resource");
 
-			foreach (XmlElement ele in resources)
-			{
-				if (!ulong.TryParse(ele.Attributes["id"].Value, NumberStyles.AllowHexSpecifier, CultureInfo.CurrentCulture, out ulong resourceID))
-					continue;
+            foreach (XmlElement ele in resources)
+            {
+                if (!ulong.TryParse(ele.Attributes["id"].Value, NumberStyles.AllowHexSpecifier, CultureInfo.CurrentCulture, out ulong resourceID))
+                    continue;
 
-				foreach (var entry in Entries)
-				{
-					if (entry.ID != resourceID)
-						continue;
+                foreach (var entry in Entries)
+                {
+                    if (entry.ID != resourceID)
+                        continue;
 
-					entry.DebugInfo.Name = ele.Attributes["name"].Value;
-					entry.DebugInfo.TypeName = ele.Attributes["type"].Value;
-					break;
-				}
-			}
-		}
+                    entry.DebugInfo.Name = ele.Attributes["name"].Value;
+                    entry.DebugInfo.TypeName = ele.Attributes["type"].Value;
+                    break;
+                }
+            }
+        }
 
         public static BundleArchive Read(string path)
         {
@@ -173,10 +173,10 @@ namespace BundleFormat
                 {
                     BinaryReader2 br = new BinaryReader2(s);
 
-					BundleArchive result = new BundleArchive();
-					result.Path = path;
+                    BundleArchive result = new BundleArchive();
+                    result.Path = path;
 
-					if (!result.Read(br))
+                    if (!result.Read(br))
                     {
                         br.Close();
 
@@ -192,529 +192,529 @@ namespace BundleFormat
                     Debug.WriteLine(ex.Message + "\n" + ex.StackTrace);
                     return null;
                 } catch (ReadFailedError ex)
-				{
-					Debug.WriteLine(ex.Message + "\n" + ex.StackTrace);
-					return null;
-				}
+                {
+                    Debug.WriteLine(ex.Message + "\n" + ex.StackTrace);
+                    return null;
+                }
             }
         }
 
-		public bool Read(BinaryReader2 br)
-		{
-			int type;
-			byte[] bytes = br.ReadBytes(4);
-			if (bytes.Matches(BND1Magic))
-				type = 1;
-			else if (bytes.Matches(BND2Magic))
-				type = 2;
-			else
-				return false;
-
-			BNDVersion = type;
-
-			switch (type)
-			{
-				case 1:
-					if (!ReadBND1(br))
-						return false;
-					break;
-				case 2:
-					if (!ReadBND2(br))
-						return false;
-					break;
-			}
-
-			br.Close();
-
-			return true;
-		}
-
-		private bool ReadBND1(BinaryReader2 br)
-		{
-			br.BigEndian = true;
-
-			// Version number?
-			br.ReadUInt32();
-
-			uint entryCount = br.ReadUInt32();
-
-			uint[] dataBlockSizes = new uint[5];
-			for (int i = 0; i < dataBlockSizes.Length; i++)
-			{
-				dataBlockSizes[i] = br.ReadUInt32();
-				br.BaseStream.Position += 4; // Padding
-			}
-
-			br.BaseStream.Position += 0x14; // Unknown Data
-
-			uint idListOffset = br.ReadUInt32();
-			uint idTableOffset = br.ReadUInt32();
-
-			br.ReadUInt32(); // dependency block
-			br.ReadUInt32(); // start of data block
-
-			Platform = BundlePlatform.X360; // Xbox only for now
-			br.ReadUInt32(); // might be platform (2 being X360)
-
-			uint compressed = br.ReadUInt32();
-			if (compressed != 0)
-				Flags = Flags.Compressed; // TODO
-			else
-				Flags = 0;
-
-			br.ReadUInt32(); // unknown purpose sometimes the same as entryCount
-
-			uint uncompressedInfoOffset = br.ReadUInt32();
-
-			br.ReadUInt32(); // main memory alignment
-			br.ReadUInt32(); // graphics memory alignment
-
-			Entries.Clear();
-
-			br.BaseStream.Position = idListOffset;
-
-			List<ulong> resourceIds = new List<ulong>();
-			for (int i = 0; i < entryCount; i++)
-				resourceIds.Add(br.ReadUInt64());
-
-			br.BaseStream.Position = idTableOffset;
-
-			foreach (ulong resourceId in resourceIds)
-			{
-				BundleEntry entry = new BundleEntry(this);
-				entry.EntryBlocks = new EntryBlock[3];
-				entry.ID = resourceId;
-
-				br.ReadUInt32(); // unknown mem stuff
-
-				entry.DependenciesListOffset = br.ReadInt32();
-				entry.Type = (EntryType)br.ReadUInt32();
-
-				//uint[] sizes = new uint[2];
-
-				if (compressed != 0)
-				{
-					//sizes[0] = br.ReadUInt32();
-					entry.EntryBlocks[0] = new EntryBlock();
-					entry.EntryBlocks[0].Compressed = true;
-					entry.EntryBlocks[0].CompressedSize = br.ReadUInt32();
-					br.ReadUInt32(); // Alignment value, should be 1
-					br.ReadUInt32(); // other blocks. Maybe used but I'm ignoring it.
-					br.ReadUInt32(); // Alignment value, should be 1
-					//sizes[1] = br.ReadUInt32();
-					entry.EntryBlocks[1] = new EntryBlock();
-					entry.EntryBlocks[1].Compressed = true;
-					entry.EntryBlocks[1].CompressedSize = br.ReadUInt32();
-					br.ReadUInt32(); // Alignment value, should be 1
-					br.ReadUInt32(); // other blocks. Maybe used but I'm ignoring it.
-					br.ReadUInt32(); // Alignment value, should be 1
-					br.ReadUInt32(); // other blocks. Maybe used but I'm ignoring it.
-					br.ReadUInt32(); // Alignment value, should be 1
-				} else
-				{
-					//sizes[0] = br.ReadUInt32();
-					entry.EntryBlocks[0] = new EntryBlock();
-					entry.EntryBlocks[0].Compressed = false;
-					entry.EntryBlocks[0].UncompressedSize = br.ReadUInt32();
-					entry.EntryBlocks[0].UncompressedAlignment = br.ReadUInt32();
-					br.ReadUInt32(); // other blocks. Maybe used but I'm ignoring it.
-					br.ReadUInt32(); // Alignment value
-					//sizes[1] = br.ReadUInt32();
-					entry.EntryBlocks[1] = new EntryBlock();
-					entry.EntryBlocks[1].Compressed = false;
-					entry.EntryBlocks[1].UncompressedSize = br.ReadUInt32();
-					entry.EntryBlocks[1].UncompressedAlignment = br.ReadUInt32();
-					br.ReadUInt32(); // other blocks. Maybe used but I'm ignoring it.
-					br.ReadUInt32(); // Alignment value
-					br.ReadUInt32(); // other blocks. Maybe used but I'm ignoring it.
-					br.ReadUInt32(); // Alignment value
-				}
-
-				uint dataBlockStartOffset = 0;
-				for (int j = 0; j < dataBlockSizes.Length; j++)
-				{
-					if (j > 0)
-						dataBlockStartOffset += dataBlockSizes[j - 1];
-
-					uint readOffset = br.ReadUInt32() + dataBlockStartOffset;
-					br.ReadUInt32(); // 1
-
-					if (j != 0 && j != 2)
-						continue; // Not supporting blocks 2, 4 and 5 right now.
-
-					int mappedBlock = j;
-					if (j == 2)
-						mappedBlock = 1;
-
-					if (entry.EntryBlocks[mappedBlock] == null)
-						entry.EntryBlocks[mappedBlock] = new EntryBlock();
-					EntryBlock entryBlock = entry.EntryBlocks[mappedBlock];
-
-					//uint readSize = sizes[mappedBlock];
-					uint readSize = compressed != 0 ? entryBlock.CompressedSize : entryBlock.UncompressedSize;
-					if (readSize == 0)
-					{
-						entryBlock.RawData = null;
-						continue;
-					}
-
-					long pos = br.BaseStream.Position;
-					br.BaseStream.Position = readOffset;
-
-					entryBlock.RawData = br.ReadBytes((int)readSize);
-
-					br.BaseStream.Position = pos;
-				}
-
-				br.BaseStream.Position += 0x14; // unknown mem stuff
-
-				Entries.Add(entry);
-			}
-
-			if (compressed != 0)
-			{
-				br.BaseStream.Position = uncompressedInfoOffset;
-				for (int i = 0; i < Entries.Count; i++)
-				{
-					BundleEntry entry = Entries[i];
-
-					//uint[] sizes = new uint[2];
-
-					//sizes[0] = br.ReadUInt32();
-					entry.EntryBlocks[0].UncompressedSize = br.ReadUInt32();
-					entry.EntryBlocks[0].UncompressedAlignment = br.ReadUInt32();
-					br.ReadUInt32(); // other blocks. Maybe used but I'm ignoring it.
-					br.ReadUInt32(); // Alignment value
-					//sizes[1] = br.ReadUInt32();
-					entry.EntryBlocks[1].UncompressedSize = br.ReadUInt32();
-					entry.EntryBlocks[1].UncompressedAlignment = br.ReadUInt32();
-					br.ReadUInt32(); // other blocks. Maybe used but I'm ignoring it.
-					br.ReadUInt32(); // Alignment value
-					br.ReadUInt32(); // other blocks. Maybe used but I'm ignoring it.
-					br.ReadUInt32(); // Alignment value
-
-					//for (int j = 0; j < 2; j++)
-					//{
-					//	EntryBlock entryBlock = entry.EntryBlocks[j];
-					//	if (sizes[j] > 0)
-					//		entryBlock.Data = entryBlock.Data.Decompress((int)sizes[j]);
-					//}
-				}
-			}
-
-			for (int i = 0; i < Entries.Count; i++)
-			{
-				BundleEntry entry = Entries[i];
-				uint depOffset = (uint)entry.DependenciesListOffset;
-				if (depOffset == 0)
-					continue;
-
-				br.BaseStream.Position = depOffset;
-
-				entry.DependencyCount = (short)br.ReadUInt32();
-				if (br.ReadUInt32() != 0)
-					return false;
-
-				for (int j = 0; j < entry.DependencyCount; j++)
-				{
-					Dependency dep = new Dependency();
-					dep.ID = br.ReadUInt64();
-					dep.EntryPointerOffset = br.ReadUInt32();
-
-					br.ReadUInt32(); // Skip
-
-					entry.Dependencies.Add(dep);
-				}
-			}
-
-			BundleEntry rst = GetEntryByID(0xC039284A);
-			if (rst == null)
-				return true;
-
-			BinaryReader2 br2 = new BinaryReader2(rst.MakeStream());
-			br2.BigEndian = false;
-
-			// TODO: Store only the debug info and not the full string
-			ResourceStringTable = br2.ReadLenString();
-
-			br2.Close();
-
-			// Cover Criterion's broken XML writer.
-			if (ResourceStringTable.StartsWith("</ResourceStringTable>"))
-				ResourceStringTable = ResourceStringTable.Remove(1, 1);
-			string badLine = "</ResourceStringTable>\n\t";
-			int index = ResourceStringTable.IndexOf(badLine);
-			if (index > -1)
-				ResourceStringTable = ResourceStringTable.Remove(index, badLine.Length);
-
-			ProcessRST(ResourceStringTable);
-
-			Entries.Remove(rst);
-
-			return true;
-		}
-
-		private bool ReadBND2(BinaryReader2 br)
-		{
-			br.BaseStream.Position += 4;
-
-			int platform = br.ReadInt32();
-			if (platform != 1)
-				platform = Util.ReverseBytes(platform);
-			Platform = (BundlePlatform)platform;
-			br.BigEndian = Console;
-
-			br.BaseStream.Position -= 8;
-			Version = br.ReadInt32();
-			if (Version != 2)
-			{
-				throw new ReadFailedError("Unsupported Bundle Version: " + Version);
-			}
-			br.BaseStream.Position += 4;
-
-			RSTOffset = br.ReadInt32();
-			EntryCount = br.ReadInt32();
-			IDBlockOffset = br.ReadInt32();
-			uint[] fileBlockOffsets = new uint[3];
-			fileBlockOffsets[0] = br.ReadUInt32();
-			fileBlockOffsets[1] = br.ReadUInt32();
-			fileBlockOffsets[2] = br.ReadUInt32();
-			Flags = (Flags)br.ReadInt32();
-
-			// 8 Bytes Padding
-
-			br.BaseStream.Position = IDBlockOffset;
-
-			for (int i = 0; i < EntryCount; i++)
-			{
-				BundleEntry entry = new BundleEntry(this);
-
-				entry.Index = i;
-
-				entry.Platform = Platform;
-
-				entry.ID = br.ReadUInt64();
+        public bool Read(BinaryReader2 br)
+        {
+            int type;
+            byte[] bytes = br.ReadBytes(4);
+            if (bytes.Matches(BND1Magic))
+                type = 1;
+            else if (bytes.Matches(BND2Magic))
+                type = 2;
+            else
+                return false;
+
+            BNDVersion = type;
+
+            switch (type)
+            {
+                case 1:
+                    if (!ReadBND1(br))
+                        return false;
+                    break;
+                case 2:
+                    if (!ReadBND2(br))
+                        return false;
+                    break;
+            }
+
+            br.Close();
+
+            return true;
+        }
+
+        private bool ReadBND1(BinaryReader2 br)
+        {
+            br.BigEndian = true;
+
+            // Version number?
+            br.ReadUInt32();
+
+            uint entryCount = br.ReadUInt32();
+
+            uint[] dataBlockSizes = new uint[5];
+            for (int i = 0; i < dataBlockSizes.Length; i++)
+            {
+                dataBlockSizes[i] = br.ReadUInt32();
+                br.BaseStream.Position += 4; // Padding
+            }
+
+            br.BaseStream.Position += 0x14; // Unknown Data
+
+            uint idListOffset = br.ReadUInt32();
+            uint idTableOffset = br.ReadUInt32();
+
+            br.ReadUInt32(); // dependency block
+            br.ReadUInt32(); // start of data block
+
+            Platform = BundlePlatform.X360; // Xbox only for now
+            br.ReadUInt32(); // might be platform (2 being X360)
+
+            uint compressed = br.ReadUInt32();
+            if (compressed != 0)
+                Flags = Flags.Compressed; // TODO
+            else
+                Flags = 0;
+
+            br.ReadUInt32(); // unknown purpose sometimes the same as entryCount
+
+            uint uncompressedInfoOffset = br.ReadUInt32();
+
+            br.ReadUInt32(); // main memory alignment
+            br.ReadUInt32(); // graphics memory alignment
+
+            Entries.Clear();
+
+            br.BaseStream.Position = idListOffset;
+
+            List<ulong> resourceIds = new List<ulong>();
+            for (int i = 0; i < entryCount; i++)
+                resourceIds.Add(br.ReadUInt64());
+
+            br.BaseStream.Position = idTableOffset;
+
+            foreach (ulong resourceId in resourceIds)
+            {
+                BundleEntry entry = new BundleEntry(this);
+                entry.EntryBlocks = new EntryBlock[3];
+                entry.ID = resourceId;
+
+                br.ReadUInt32(); // unknown mem stuff
+
+                entry.DependenciesListOffset = br.ReadInt32();
+                entry.Type = (EntryType)br.ReadUInt32();
+
+                //uint[] sizes = new uint[2];
+
+                if (compressed != 0)
+                {
+                    //sizes[0] = br.ReadUInt32();
+                    entry.EntryBlocks[0] = new EntryBlock();
+                    entry.EntryBlocks[0].Compressed = true;
+                    entry.EntryBlocks[0].CompressedSize = br.ReadUInt32();
+                    br.ReadUInt32(); // Alignment value, should be 1
+                    br.ReadUInt32(); // other blocks. Maybe used but I'm ignoring it.
+                    br.ReadUInt32(); // Alignment value, should be 1
+                    //sizes[1] = br.ReadUInt32();
+                    entry.EntryBlocks[1] = new EntryBlock();
+                    entry.EntryBlocks[1].Compressed = true;
+                    entry.EntryBlocks[1].CompressedSize = br.ReadUInt32();
+                    br.ReadUInt32(); // Alignment value, should be 1
+                    br.ReadUInt32(); // other blocks. Maybe used but I'm ignoring it.
+                    br.ReadUInt32(); // Alignment value, should be 1
+                    br.ReadUInt32(); // other blocks. Maybe used but I'm ignoring it.
+                    br.ReadUInt32(); // Alignment value, should be 1
+                } else
+                {
+                    //sizes[0] = br.ReadUInt32();
+                    entry.EntryBlocks[0] = new EntryBlock();
+                    entry.EntryBlocks[0].Compressed = false;
+                    entry.EntryBlocks[0].UncompressedSize = br.ReadUInt32();
+                    entry.EntryBlocks[0].UncompressedAlignment = br.ReadUInt32();
+                    br.ReadUInt32(); // other blocks. Maybe used but I'm ignoring it.
+                    br.ReadUInt32(); // Alignment value
+                    //sizes[1] = br.ReadUInt32();
+                    entry.EntryBlocks[1] = new EntryBlock();
+                    entry.EntryBlocks[1].Compressed = false;
+                    entry.EntryBlocks[1].UncompressedSize = br.ReadUInt32();
+                    entry.EntryBlocks[1].UncompressedAlignment = br.ReadUInt32();
+                    br.ReadUInt32(); // other blocks. Maybe used but I'm ignoring it.
+                    br.ReadUInt32(); // Alignment value
+                    br.ReadUInt32(); // other blocks. Maybe used but I'm ignoring it.
+                    br.ReadUInt32(); // Alignment value
+                }
+
+                uint dataBlockStartOffset = 0;
+                for (int j = 0; j < dataBlockSizes.Length; j++)
+                {
+                    if (j > 0)
+                        dataBlockStartOffset += dataBlockSizes[j - 1];
+
+                    uint readOffset = br.ReadUInt32() + dataBlockStartOffset;
+                    br.ReadUInt32(); // 1
+
+                    if (j != 0 && j != 2)
+                        continue; // Not supporting blocks 2, 4 and 5 right now.
+
+                    int mappedBlock = j;
+                    if (j == 2)
+                        mappedBlock = 1;
+
+                    if (entry.EntryBlocks[mappedBlock] == null)
+                        entry.EntryBlocks[mappedBlock] = new EntryBlock();
+                    EntryBlock entryBlock = entry.EntryBlocks[mappedBlock];
+
+                    //uint readSize = sizes[mappedBlock];
+                    uint readSize = compressed != 0 ? entryBlock.CompressedSize : entryBlock.UncompressedSize;
+                    if (readSize == 0)
+                    {
+                        entryBlock.RawData = null;
+                        continue;
+                    }
+
+                    long pos = br.BaseStream.Position;
+                    br.BaseStream.Position = readOffset;
+
+                    entryBlock.RawData = br.ReadBytes((int)readSize);
+
+                    br.BaseStream.Position = pos;
+                }
+
+                br.BaseStream.Position += 0x14; // unknown mem stuff
+
+                Entries.Add(entry);
+            }
+
+            if (compressed != 0)
+            {
+                br.BaseStream.Position = uncompressedInfoOffset;
+                for (int i = 0; i < Entries.Count; i++)
+                {
+                    BundleEntry entry = Entries[i];
+
+                    //uint[] sizes = new uint[2];
+
+                    //sizes[0] = br.ReadUInt32();
+                    entry.EntryBlocks[0].UncompressedSize = br.ReadUInt32();
+                    entry.EntryBlocks[0].UncompressedAlignment = br.ReadUInt32();
+                    br.ReadUInt32(); // other blocks. Maybe used but I'm ignoring it.
+                    br.ReadUInt32(); // Alignment value
+                    //sizes[1] = br.ReadUInt32();
+                    entry.EntryBlocks[1].UncompressedSize = br.ReadUInt32();
+                    entry.EntryBlocks[1].UncompressedAlignment = br.ReadUInt32();
+                    br.ReadUInt32(); // other blocks. Maybe used but I'm ignoring it.
+                    br.ReadUInt32(); // Alignment value
+                    br.ReadUInt32(); // other blocks. Maybe used but I'm ignoring it.
+                    br.ReadUInt32(); // Alignment value
+
+                    //for (int j = 0; j < 2; j++)
+                    //{
+                    //    EntryBlock entryBlock = entry.EntryBlocks[j];
+                    //    if (sizes[j] > 0)
+                    //        entryBlock.Data = entryBlock.Data.Decompress((int)sizes[j]);
+                    //}
+                }
+            }
+
+            for (int i = 0; i < Entries.Count; i++)
+            {
+                BundleEntry entry = Entries[i];
+                uint depOffset = (uint)entry.DependenciesListOffset;
+                if (depOffset == 0)
+                    continue;
+
+                br.BaseStream.Position = depOffset;
+
+                entry.DependencyCount = (short)br.ReadUInt32();
+                if (br.ReadUInt32() != 0)
+                    return false;
+
+                for (int j = 0; j < entry.DependencyCount; j++)
+                {
+                    Dependency dep = new Dependency();
+                    dep.ID = br.ReadUInt64();
+                    dep.EntryPointerOffset = br.ReadUInt32();
+
+                    br.ReadUInt32(); // Skip
+
+                    entry.Dependencies.Add(dep);
+                }
+            }
+
+            BundleEntry rst = GetEntryByID(0xC039284A);
+            if (rst == null)
+                return true;
+
+            BinaryReader2 br2 = new BinaryReader2(rst.MakeStream());
+            br2.BigEndian = false;
+
+            // TODO: Store only the debug info and not the full string
+            ResourceStringTable = br2.ReadLenString();
+
+            br2.Close();
+
+            // Cover Criterion's broken XML writer.
+            if (ResourceStringTable.StartsWith("</ResourceStringTable>"))
+                ResourceStringTable = ResourceStringTable.Remove(1, 1);
+            string badLine = "</ResourceStringTable>\n\t";
+            int index = ResourceStringTable.IndexOf(badLine);
+            if (index > -1)
+                ResourceStringTable = ResourceStringTable.Remove(index, badLine.Length);
+
+            ProcessRST(ResourceStringTable);
+
+            Entries.Remove(rst);
+
+            return true;
+        }
+
+        private bool ReadBND2(BinaryReader2 br)
+        {
+            br.BaseStream.Position += 4;
+
+            int platform = br.ReadInt32();
+            if (platform != 1)
+                platform = Util.ReverseBytes(platform);
+            Platform = (BundlePlatform)platform;
+            br.BigEndian = Console;
+
+            br.BaseStream.Position -= 8;
+            Version = br.ReadInt32();
+            if (Version != 2)
+            {
+                throw new ReadFailedError("Unsupported Bundle Version: " + Version);
+            }
+            br.BaseStream.Position += 4;
+
+            RSTOffset = br.ReadInt32();
+            EntryCount = br.ReadInt32();
+            IDBlockOffset = br.ReadInt32();
+            uint[] fileBlockOffsets = new uint[3];
+            fileBlockOffsets[0] = br.ReadUInt32();
+            fileBlockOffsets[1] = br.ReadUInt32();
+            fileBlockOffsets[2] = br.ReadUInt32();
+            Flags = (Flags)br.ReadInt32();
+
+            // 8 Bytes Padding
+
+            br.BaseStream.Position = IDBlockOffset;
+
+            for (int i = 0; i < EntryCount; i++)
+            {
+                BundleEntry entry = new BundleEntry(this);
+
+                entry.Index = i;
+
+                entry.Platform = Platform;
+
+                entry.ID = br.ReadUInt64();
 
                 entry.References = br.ReadUInt64();
 
-				entry.EntryBlocks = new EntryBlock[3];
-				for (int j = 0; j < entry.EntryBlocks.Length; j++)
-				{
-					entry.EntryBlocks[j] = new EntryBlock();
-					entry.EntryBlocks[j].Compressed = Flags.HasFlag(Flags.Compressed);
-				}
+                entry.EntryBlocks = new EntryBlock[3];
+                for (int j = 0; j < entry.EntryBlocks.Length; j++)
+                {
+                    entry.EntryBlocks[j] = new EntryBlock();
+                    entry.EntryBlocks[j].Compressed = Flags.HasFlag(Flags.Compressed);
+                }
 
-				//uint[] blockUncompressedSizes = new uint[3];
+                //uint[] blockUncompressedSizes = new uint[3];
 
-				for (int j = 0; j < entry.EntryBlocks.Length; j++)
-				{
-					uint uncompressedSize = br.ReadUInt32();
-					//blockUncompressedSizes[j] = uncompressedSize & ~(0xFU << 28);
-					entry.EntryBlocks[j].UncompressedSize = uncompressedSize & ~(0xFU << 28);
-					entry.EntryBlocks[j].UncompressedAlignment = (uint)(1 << ((int)uncompressedSize >> 28));
-				}
+                for (int j = 0; j < entry.EntryBlocks.Length; j++)
+                {
+                    uint uncompressedSize = br.ReadUInt32();
+                    //blockUncompressedSizes[j] = uncompressedSize & ~(0xFU << 28);
+                    entry.EntryBlocks[j].UncompressedSize = uncompressedSize & ~(0xFU << 28);
+                    entry.EntryBlocks[j].UncompressedAlignment = (uint)(1 << ((int)uncompressedSize >> 28));
+                }
 
-				//uint[] blockCompressedSizes = new uint[3];
+                //uint[] blockCompressedSizes = new uint[3];
 
-				for (int j = 0; j < entry.EntryBlocks.Length; j++)
-				{
-					//blockCompressedSizes[j] = br.ReadUInt32();
-					entry.EntryBlocks[j].CompressedSize = br.ReadUInt32();
-				}
+                for (int j = 0; j < entry.EntryBlocks.Length; j++)
+                {
+                    //blockCompressedSizes[j] = br.ReadUInt32();
+                    entry.EntryBlocks[j].CompressedSize = br.ReadUInt32();
+                }
 
-				for (int j = 0; j < entry.EntryBlocks.Length; j++)
-				{
-					uint blockOffset = br.ReadUInt32();
-					long lastAddr = br.BaseStream.Position;
-					br.BaseStream.Position = blockOffset + fileBlockOffsets[j];
+                for (int j = 0; j < entry.EntryBlocks.Length; j++)
+                {
+                    uint blockOffset = br.ReadUInt32();
+                    long lastAddr = br.BaseStream.Position;
+                    br.BaseStream.Position = blockOffset + fileBlockOffsets[j];
 
-					EntryBlock block = entry.EntryBlocks[j];
+                    EntryBlock block = entry.EntryBlocks[j];
 
-					bool compressed = Flags.HasFlag(Flags.Compressed);
+                    bool compressed = Flags.HasFlag(Flags.Compressed);
 
-					//uint readSize = compressed ? blockCompressedSizes[j] : blockUncompressedSizes[j];
-					uint readSize = compressed ? entry.EntryBlocks[j].CompressedSize : entry.EntryBlocks[j].UncompressedSize;
-					if (readSize == 0)
-					{
-						block.RawData = null;
-						br.BaseStream.Position = lastAddr;
-						continue;
-					}
+                    //uint readSize = compressed ? blockCompressedSizes[j] : blockUncompressedSizes[j];
+                    uint readSize = compressed ? entry.EntryBlocks[j].CompressedSize : entry.EntryBlocks[j].UncompressedSize;
+                    if (readSize == 0)
+                    {
+                        block.RawData = null;
+                        br.BaseStream.Position = lastAddr;
+                        continue;
+                    }
 
-					block.RawData = br.ReadBytes((int)readSize);
-					//if (compressed)
-					//	block.Data = block.Data.Decompress((int)blockUncompressedSizes[j]);
-					br.BaseStream.Position = lastAddr;
-				}
+                    block.RawData = br.ReadBytes((int)readSize);
+                    //if (compressed)
+                    //    block.Data = block.Data.Decompress((int)blockUncompressedSizes[j]);
+                    br.BaseStream.Position = lastAddr;
+                }
 
-				entry.DependenciesListOffset = br.ReadInt32();
-				entry.Type = (EntryType)br.ReadInt32();
-				entry.DependencyCount = br.ReadInt16();
+                entry.DependenciesListOffset = br.ReadInt32();
+                entry.Type = (EntryType)br.ReadInt32();
+                entry.DependencyCount = br.ReadInt16();
 
                 br.BaseStream.Position += 2; // Padding
 
                 entry.Dirty = false;
 
-				Entries.Add(entry);
+                Entries.Add(entry);
             }
 
-			if (Flags.HasFlag(Flags.HasResourceStringTable))
-			{
-				br.BaseStream.Position = RSTOffset;
+            if (Flags.HasFlag(Flags.HasResourceStringTable))
+            {
+                br.BaseStream.Position = RSTOffset;
 
-				// TODO: Store only the debug info and not the full string
-				ResourceStringTable = br.ReadCStr();
+                // TODO: Store only the debug info and not the full string
+                ResourceStringTable = br.ReadCStr();
 
-				ProcessRST(ResourceStringTable);
-			}
+                ProcessRST(ResourceStringTable);
+            }
 
-			return true;
+            return true;
         }
 
-		public void Write(string path)
-		{
-			//if (Console)
-			//    ConvertToPC();
-			Stream s = File.Open(path, FileMode.Create);
-			BinaryWriter bw = new BinaryWriter(s);
+        public void Write(string path)
+        {
+            //if (Console)
+            //    ConvertToPC();
+            Stream s = File.Open(path, FileMode.Create);
+            BinaryWriter bw = new BinaryWriter(s);
 
-			Write(bw);
+            Write(bw);
 
-			bw.Flush();
-			bw.Close();
-		}
+            bw.Flush();
+            bw.Close();
+        }
 
-		public void Write(BinaryWriter bw)
-		{
-			bw.Write(BundleArchive.BND2Magic);
-			bw.Write(this.Version);
-			bw.Write((int)this.Platform);
+        public void Write(BinaryWriter bw)
+        {
+            bw.Write(BundleArchive.BND2Magic);
+            bw.Write(this.Version);
+            bw.Write((int)this.Platform);
 
-			long rstOffset = bw.BaseStream.Position;
-			bw.Write((int)0);
+            long rstOffset = bw.BaseStream.Position;
+            bw.Write((int)0);
 
-			bw.Write(this.Entries.Count);
+            bw.Write(this.Entries.Count);
 
-			long idBlockOffsetPos = bw.BaseStream.Position;
-			bw.Write((int)0);
+            long idBlockOffsetPos = bw.BaseStream.Position;
+            bw.Write((int)0);
 
-			long[] fileBlockOffsetsPos = new long[3];
+            long[] fileBlockOffsetsPos = new long[3];
 
-			for (int i = 0; i < fileBlockOffsetsPos.Length; i++)
-			{
-				fileBlockOffsetsPos[i] = bw.BaseStream.Position;
-				bw.BaseStream.Position += 4;
-			}
+            for (int i = 0; i < fileBlockOffsetsPos.Length; i++)
+            {
+                fileBlockOffsetsPos[i] = bw.BaseStream.Position;
+                bw.BaseStream.Position += 4;
+            }
 
-			bw.Write((int)this.Flags);
+            bw.Write((int)this.Flags);
 
-			bw.Align(16);
+            bw.Align(16);
 
-			long currentOffset = bw.BaseStream.Position;
-			bw.BaseStream.Position = rstOffset;
-			bw.Write((uint)currentOffset);
-			bw.BaseStream.Position = currentOffset;
+            long currentOffset = bw.BaseStream.Position;
+            bw.BaseStream.Position = rstOffset;
+            bw.Write((uint)currentOffset);
+            bw.BaseStream.Position = currentOffset;
 
-			if (this.Flags.HasFlag(Flags.HasResourceStringTable))
-			{
-				// TODO: Rebuild RST from DebugInfo
-				bw.WriteCStr(this.ResourceStringTable);
+            if (this.Flags.HasFlag(Flags.HasResourceStringTable))
+            {
+                // TODO: Rebuild RST from DebugInfo
+                bw.WriteCStr(this.ResourceStringTable);
 
-				bw.Align(16);
-			}
+                bw.Align(16);
+            }
 
-			// ID Block
-			currentOffset = bw.BaseStream.Position;
-			bw.Seek((int)idBlockOffsetPos, SeekOrigin.Begin);
-			bw.Write((int)currentOffset);
-			bw.Seek((int)currentOffset, SeekOrigin.Begin);
+            // ID Block
+            currentOffset = bw.BaseStream.Position;
+            bw.Seek((int)idBlockOffsetPos, SeekOrigin.Begin);
+            bw.Write((int)currentOffset);
+            bw.Seek((int)currentOffset, SeekOrigin.Begin);
 
-			List<long[]> entryDataPointerPos = new List<long[]>();
+            List<long[]> entryDataPointerPos = new List<long[]>();
 
-			List<byte[][]> compressedBlocks = new List<byte[][]>();
+            List<byte[][]> compressedBlocks = new List<byte[][]>();
 
-			for (int i = 0; i < this.Entries.Count; i++)
-			{
-				BundleEntry entry = this.Entries[i];
+            for (int i = 0; i < this.Entries.Count; i++)
+            {
+                BundleEntry entry = this.Entries[i];
 
-				compressedBlocks.Add(new byte[3][]);
+                compressedBlocks.Add(new byte[3][]);
 
-				bw.Write(entry.ID);
-				bw.Write(entry.References);
+                bw.Write(entry.ID);
+                bw.Write(entry.References);
 
-				for (int j = 0; j < entry.EntryBlocks.Length; j++)
-				{
-					EntryBlock entryBlock = entry.EntryBlocks[j];
-					uint uncompressedSize = 0;
-					if (entryBlock.Data != null)
-						uncompressedSize = (uint)entryBlock.Data.Length;
-					//self.Write((entryBlock.UncompressedAlignment << 28) | uncompressedSize);
-					bw.Write((uint)(uncompressedSize | (BitScan.BitScanReverse(entryBlock.UncompressedAlignment) << 28)));
-				}
+                for (int j = 0; j < entry.EntryBlocks.Length; j++)
+                {
+                    EntryBlock entryBlock = entry.EntryBlocks[j];
+                    uint uncompressedSize = 0;
+                    if (entryBlock.Data != null)
+                        uncompressedSize = (uint)entryBlock.Data.Length;
+                    //self.Write((entryBlock.UncompressedAlignment << 28) | uncompressedSize);
+                    bw.Write((uint)(uncompressedSize | (BitScan.BitScanReverse(entryBlock.UncompressedAlignment) << 28)));
+                }
 
-				for (int j = 0; j < entry.EntryBlocks.Length; j++)
-				{
-					EntryBlock entryBlock = entry.EntryBlocks[j];
-					if (entryBlock.Data == null)
-						bw.Write((uint)0);
-					else
-					{
-						compressedBlocks[i][j] = entryBlock.Data.Compress();
-						bw.Write(compressedBlocks[i][j].Length);
-					}
-				}
+                for (int j = 0; j < entry.EntryBlocks.Length; j++)
+                {
+                    EntryBlock entryBlock = entry.EntryBlocks[j];
+                    if (entryBlock.Data == null)
+                        bw.Write((uint)0);
+                    else
+                    {
+                        compressedBlocks[i][j] = entryBlock.Data.Compress();
+                        bw.Write(compressedBlocks[i][j].Length);
+                    }
+                }
 
-				entryDataPointerPos.Add(new long[3]);
-				for (int j = 0; j < entryDataPointerPos[i].Length; j++)
-				{
-					entryDataPointerPos[i][j] = bw.BaseStream.Position;
-					bw.BaseStream.Position += 4;
-				}
+                entryDataPointerPos.Add(new long[3]);
+                for (int j = 0; j < entryDataPointerPos[i].Length; j++)
+                {
+                    entryDataPointerPos[i][j] = bw.BaseStream.Position;
+                    bw.BaseStream.Position += 4;
+                }
 
-				bw.Write(entry.DependenciesListOffset);
-				bw.Write((int)entry.Type);
-				bw.Write(entry.DependencyCount);
+                bw.Write(entry.DependenciesListOffset);
+                bw.Write((int)entry.Type);
+                bw.Write(entry.DependencyCount);
 
-				bw.BaseStream.Position += 2; // Padding
-			}
+                bw.BaseStream.Position += 2; // Padding
+            }
 
-			// Data Block
-			for (int i = 0; i < 3; i++)
-			{
-				long blockStart = bw.BaseStream.Position;
-				bw.BaseStream.Position = fileBlockOffsetsPos[i];
-				bw.Write((uint)blockStart);
-				bw.BaseStream.Position = blockStart;
+            // Data Block
+            for (int i = 0; i < 3; i++)
+            {
+                long blockStart = bw.BaseStream.Position;
+                bw.BaseStream.Position = fileBlockOffsetsPos[i];
+                bw.Write((uint)blockStart);
+                bw.BaseStream.Position = blockStart;
 
-				for (int j = 0; j < this.Entries.Count; j++)
-				{
-					BundleEntry entry = this.Entries[j];
-					EntryBlock entryBlock = entry.EntryBlocks[i];
-					bool compressed = this.Flags.HasFlag(Flags.Compressed);
-					uint size = compressed ? (compressedBlocks[j][i] == null ? 0 : (uint)compressedBlocks[j][i].Length) : (uint)entryBlock.Data.Length;
+                for (int j = 0; j < this.Entries.Count; j++)
+                {
+                    BundleEntry entry = this.Entries[j];
+                    EntryBlock entryBlock = entry.EntryBlocks[i];
+                    bool compressed = this.Flags.HasFlag(Flags.Compressed);
+                    uint size = compressed ? (compressedBlocks[j][i] == null ? 0 : (uint)compressedBlocks[j][i].Length) : (uint)entryBlock.Data.Length;
 
-					if (size > 0)
-					{
-						long pos = bw.BaseStream.Position;
-						bw.BaseStream.Position = entryDataPointerPos[j][i];
-						bw.Write((uint)(pos - blockStart));
-						bw.BaseStream.Position = pos;
+                    if (size > 0)
+                    {
+                        long pos = bw.BaseStream.Position;
+                        bw.BaseStream.Position = entryDataPointerPos[j][i];
+                        bw.Write((uint)(pos - blockStart));
+                        bw.BaseStream.Position = pos;
 
-						if (compressed)
-							bw.Write(compressedBlocks[j][i]);
-						else
-							bw.Write(entryBlock.Data);
+                        if (compressed)
+                            bw.Write(compressedBlocks[j][i]);
+                        else
+                            bw.Write(entryBlock.Data);
 
-						bw.Align((i != 0 && j != this.Entries.Count - 1) ? (byte)0x80 : (byte)16);
-					}
-				}
+                        bw.Align((i != 0 && j != this.Entries.Count - 1) ? (byte)0x80 : (byte)16);
+                    }
+                }
 
-				if (i != 2)
-					bw.Align(0x80);
-			}
-		}
+                if (i != 2)
+                    bw.Align(0x80);
+            }
+        }
 
-		public static bool IsBundle(string path)
+        public static bool IsBundle(string path)
         {
             bool result;
 
@@ -802,38 +802,38 @@ namespace BundleFormat
             br.BigEndian = platform == BundlePlatform.X360 || platform == BundlePlatform.PS3;
             
             br.BaseStream.Position = 0xC;
-			uint rstOffset = br.ReadUInt32();
+            uint rstOffset = br.ReadUInt32();
             int fileCount = br.ReadInt32();
             int metaStart = br.ReadInt32();
 
-			br.BaseStream.Position += 0xC;
-			Flags flags = (Flags)br.ReadInt32();
+            br.BaseStream.Position += 0xC;
+            Flags flags = (Flags)br.ReadInt32();
 
-			Dictionary<ulong, DebugInfo> debugInfo = null;
+            Dictionary<ulong, DebugInfo> debugInfo = null;
 
-			if (flags.HasFlag(Flags.HasResourceStringTable))
-			{
-				br.BaseStream.Position = rstOffset;
+            if (flags.HasFlag(Flags.HasResourceStringTable))
+            {
+                br.BaseStream.Position = rstOffset;
 
-				// TODO: Store only the debug info and not the full string
-				string rst = br.ReadCStr();
+                // TODO: Store only the debug info and not the full string
+                string rst = br.ReadCStr();
 
-				debugInfo = GetDebugInfoFromRST(rst);
-			}
+                debugInfo = GetDebugInfoFromRST(rst);
+            }
 
-			br.BaseStream.Position = metaStart;
+            br.BaseStream.Position = metaStart;
 
-			for (int i = 0; i < fileCount; i++)
+            for (int i = 0; i < fileCount; i++)
             {
                 uint id = br.ReadUInt32();
                 br.BaseStream.Position += 0x34;
                 EntryType type = (EntryType)br.ReadUInt32();
                 br.BaseStream.Position += 0x4;
 
-				DebugInfo debug = default;
-				
-				if (debugInfo != null && debugInfo.ContainsKey(id))
-					debug = debugInfo[id];
+                DebugInfo debug = default;
+                
+                if (debugInfo != null && debugInfo.ContainsKey(id))
+                    debug = debugInfo[id];
 
                 result.Add(new EntryInfo(id, type, path, debug));
             }

--- a/BundleFormat/BundleCache.cs
+++ b/BundleFormat/BundleCache.cs
@@ -14,7 +14,7 @@ namespace BundleFormat
         public static Dictionary<ulong, int> Files = new Dictionary<ulong, int>();
         public static Dictionary<ulong, EntryInfo> EntryInfos = new Dictionary<ulong, EntryInfo>();
 
-		public static string GetFileByEntryID(ulong entryID)
+        public static string GetFileByEntryID(ulong entryID)
         {
             if (!Files.ContainsKey(entryID))
                 return null;
@@ -28,19 +28,19 @@ namespace BundleFormat
             return EntryInfos[entryID];
         }
 
-		public static DebugInfo GetEntryDebugInfoByID(ulong entryID)
-		{
-			if (!EntryInfos.ContainsKey(entryID))
-				return default;
-			return EntryInfos[entryID].DebugInfo;
-		}
+        public static DebugInfo GetEntryDebugInfoByID(ulong entryID)
+        {
+            if (!EntryInfos.ContainsKey(entryID))
+                return default;
+            return EntryInfos[entryID].DebugInfo;
+        }
 
-		public static string GetEntryNameByID(ulong entryID)
-		{
-			return GetEntryDebugInfoByID(entryID).Name;
-		}
+        public static string GetEntryNameByID(ulong entryID)
+        {
+            return GetEntryDebugInfoByID(entryID).Name;
+        }
 
-		public static string GetRelativePath(string path)
+        public static string GetRelativePath(string path)
         {
             string file = path.Replace('\\', '/').Replace(BundleCache.CurrentPath.Replace('\\', '/'), "");
 

--- a/BundleFormat/BundleEntry.cs
+++ b/BundleFormat/BundleEntry.cs
@@ -11,94 +11,94 @@ using Microsoft.SqlServer.Server;
 
 namespace BundleFormat
 {
-	public class EntryBlock
-	{
-		public bool Compressed;
-		public uint CompressedSize;
-		public uint UncompressedSize;
-		public uint UncompressedAlignment; // default depending on file type
-		public byte[] RawData;
-		public byte[] Data
-		{
-			get
-			{
-				if (RawData == null)
-					return null;
+    public class EntryBlock
+    {
+        public bool Compressed;
+        public uint CompressedSize;
+        public uint UncompressedSize;
+        public uint UncompressedAlignment; // default depending on file type
+        public byte[] RawData;
+        public byte[] Data
+        {
+            get
+            {
+                if (RawData == null)
+                    return null;
 
-				if (Compressed)
-					return RawData.Decompress((int)UncompressedSize);
+                if (Compressed)
+                    return RawData.Decompress((int)UncompressedSize);
 
-				return RawData;
-			}
-			set
-			{
-				if (Compressed)
-					RawData = value.Compress();
-				else
-					RawData = value;
+                return RawData;
+            }
+            set
+            {
+                if (Compressed)
+                    RawData = value.Compress();
+                else
+                    RawData = value;
 
-				UncompressedSize = (uint)value.Length;
-				CompressedSize = (uint)RawData.Length;
-			}
-		}
-	}
+                UncompressedSize = (uint)value.Length;
+                CompressedSize = (uint)RawData.Length;
+            }
+        }
+    }
 
     public class EntryInfo
     {
         public uint ID;
         public EntryType Type;
         public string Path;
-		public DebugInfo DebugInfo;
+        public DebugInfo DebugInfo;
 
         public EntryInfo(uint id, EntryType type, string path, DebugInfo debugInfo)
         {
             ID = id;
             Type = type;
             Path = path;
-			DebugInfo = debugInfo;
+            DebugInfo = debugInfo;
         }
     }
 
-	public struct Dependency
-	{
-		public ulong ID;
-		public uint EntryPointerOffset;
-	}
+    public struct Dependency
+    {
+        public ulong ID;
+        public uint EntryPointerOffset;
+    }
 
-	public struct DebugInfo
-	{
-		public string Name;
-		public string TypeName;
-	}
+    public struct DebugInfo
+    {
+        public string Name;
+        public string TypeName;
+    }
 
-	/*public struct BundleReference
-	{
-		public string Path;
-		public uint EntryCount;
-	}*/
+    /*public struct BundleReference
+    {
+        public string Path;
+        public uint EntryCount;
+    }*/
 
     public class BundleEntry
     {
-		public BundleArchive Archive;
-		//public BundleReference Archive;
+        public BundleArchive Archive;
+        //public BundleReference Archive;
 
-		public int Index;
+        public int Index;
 
         public ulong ID;
         public ulong References;
-		public int DependenciesListOffset;
+        public int DependenciesListOffset;
         public short DependencyCount;
-		public List<Dependency> Dependencies;
+        public List<Dependency> Dependencies;
 
-		public DebugInfo DebugInfo;
+        public DebugInfo DebugInfo;
 
-		public EntryBlock[] EntryBlocks;
+        public EntryBlock[] EntryBlocks;
 
-		public bool HasHeader => HasSection(0);
+        public bool HasHeader => HasSection(0);
         public bool HasBody => HasSection(1);
-		public bool HasThird => HasSection(2);
+        public bool HasThird => HasSection(2);
 
-		public EntryType Type;
+        public EntryType Type;
 
         public BundlePlatform Platform;
         public bool Console => Platform == BundlePlatform.X360 || Platform == BundlePlatform.PS3;
@@ -107,27 +107,27 @@ namespace BundleFormat
 
         public BundleEntry(BundleArchive archive)
         {
-			Archive = archive;
-			/*Archive = new BundleReference();
-			Archive.Path = archive.Path;
-			Archive.EntryCount = (uint)archive.Entries.Count;*/
-			Dependencies = new List<Dependency>();
+            Archive = archive;
+            /*Archive = new BundleReference();
+            Archive.Path = archive.Path;
+            Archive.EntryCount = (uint)archive.Entries.Count;*/
+            Dependencies = new List<Dependency>();
         }
 
-		public bool HasSection(int section)
-		{
-			return EntryBlocks != null &&
-				   section < EntryBlocks.Length &&
-				   section >= 0 &&
-				   EntryBlocks[section] != null &&
-				   EntryBlocks[section].Data != null &&
-				   EntryBlocks[section].Data.Length > 0;
-		}
+        public bool HasSection(int section)
+        {
+            return EntryBlocks != null &&
+                   section < EntryBlocks.Length &&
+                   section >= 0 &&
+                   EntryBlocks[section] != null &&
+                   EntryBlocks[section].Data != null &&
+                   EntryBlocks[section].Data.Length > 0;
+        }
 
         public MemoryStream MakeStream(bool body = false)
         {
-			if (EntryBlocks == null)
-				return null;
+            if (EntryBlocks == null)
+                return null;
 
             if (body)
                 return new MemoryStream(EntryBlocks[1].Data);
@@ -138,41 +138,41 @@ namespace BundleFormat
         {
             List<BundleDependency> result = new List<BundleDependency>();
 
-			if (Dependencies.Count > 0)
-			{
-				for (int i = 0; i < Dependencies.Count; i++)
-				{
-					BundleDependency dependency = new BundleDependency();
+            if (Dependencies.Count > 0)
+            {
+                for (int i = 0; i < Dependencies.Count; i++)
+                {
+                    BundleDependency dependency = new BundleDependency();
 
-					dependency.EntryID = Dependencies[i].ID;
-					dependency.EntryPointerOffset = (int)Dependencies[i].EntryPointerOffset;
+                    dependency.EntryID = Dependencies[i].ID;
+                    dependency.EntryPointerOffset = (int)Dependencies[i].EntryPointerOffset;
 
-					BundleEntry entry = null;
+                    BundleEntry entry = null;
 
-					/*string file = BundleCache.GetFileByEntryID(dependency.EntryID);
-					if (!string.IsNullOrEmpty(file))
-					{
-						BundleArchive archive = BundleArchive.Read(file, dependency.EntryID);
-						entry = archive.GetEntryByID(dependency.EntryID);
-					}*/
-					//}
+                    /*string file = BundleCache.GetFileByEntryID(dependency.EntryID);
+                    if (!string.IsNullOrEmpty(file))
+                    {
+                        BundleArchive archive = BundleArchive.Read(file, dependency.EntryID);
+                        entry = archive.GetEntryByID(dependency.EntryID);
+                    }*/
+                    //}
 
-					// TODO
-					for (int j = 0; j < Archive.Entries.Count; j++)
-					{
-						if (Archive.Entries[j].ID != dependency.EntryID)
-							continue;
+                    // TODO
+                    for (int j = 0; j < Archive.Entries.Count; j++)
+                    {
+                        if (Archive.Entries[j].ID != dependency.EntryID)
+                            continue;
 
-						dependency.EntryIndex = j;
-						entry = Archive.Entries[j];
-					}
+                        dependency.EntryIndex = j;
+                        entry = Archive.Entries[j];
+                    }
 
-					dependency.Entry = entry;
+                    dependency.Entry = entry;
 
-					result.Add(dependency);
-				}
-				return result;
-			}
+                    result.Add(dependency);
+                }
+                return result;
+            }
 
             MemoryStream ms = MakeStream();
             BinaryReader2 br = new BinaryReader2(ms);
@@ -190,15 +190,15 @@ namespace BundleFormat
 
                 BundleEntry entry = null;
 
-				/*string file = BundleCache.GetFileByEntryID(bundleDependency.EntryID);
-				if (!string.IsNullOrEmpty(file))
-				{
-					BundleArchive archive = BundleArchive.Read(file, bundleDependency.EntryID);
-					entry = archive.GetEntryByID(bundleDependency.EntryID);
-				}*/
+                /*string file = BundleCache.GetFileByEntryID(bundleDependency.EntryID);
+                if (!string.IsNullOrEmpty(file))
+                {
+                    BundleArchive archive = BundleArchive.Read(file, bundleDependency.EntryID);
+                    entry = archive.GetEntryByID(bundleDependency.EntryID);
+                }*/
 
-				// TODO
-				for (int j = 0; j < Archive.Entries.Count; j++)
+                // TODO
+                for (int j = 0; j < Archive.Entries.Count; j++)
                 {
                     if (Archive.Entries[j].ID != bundleDependency.EntryID)
                         continue;
@@ -210,7 +210,7 @@ namespace BundleFormat
                 bundleDependency.Entry = entry;
 
                 result.Add(bundleDependency);
-			}
+            }
 
             br.Close();
             ms.Close();
@@ -220,8 +220,8 @@ namespace BundleFormat
 
         public string DetectName()
         {
-			if (!string.IsNullOrWhiteSpace(DebugInfo.Name))
-				return DebugInfo.Name;
+            if (!string.IsNullOrWhiteSpace(DebugInfo.Name))
+                return DebugInfo.Name;
 
             string theName = "worldvault";
             ulong theID = Crc32.HashCrc32B(theName);

--- a/BundleFormat/EntryType.cs
+++ b/BundleFormat/EntryType.cs
@@ -8,137 +8,137 @@ namespace BundleFormat
 {
     public enum EntryType
     {
-		// List pulled from RED
+        // List pulled from RED
 
-		// Standard types, shared between games
-		Texture = 0x00, // Also called: RwRaster, PlaneTexture, TexturePage
-		Material = 0x01, // Also called: RwMaterial, MaterialAssembly
-		RenderableMesh = 0x02, // Also called: Renderable; likely deprecated
-		TextFile = 0x03,
-		DrawIndexParams = 0x04,
-		IndexBuffer = 0x05,
-		MeshState = 0x06,
-		VertexBuffer = 0x09,
-		VertexDescriptor = 0x0A, // Also called: RwVertexDesc
-		MaterialCRC32 = 0x0B, // Also called: RwMaterialCRC32
-		Renderable = 0x0C, // Also called: RwRenderable, GtRenderable
-		MaterialTechnique = 0x0D,
-		TextureState = 0x0E, // Also called: RwTextureState
-		MaterialState = 0x0F, // Also called: BlendState
-		DepthStencilState = 0x10,
-		RasterizerState = 0x11,
-		ShaderProgramBuffer = 0x12, // Also called: RwShaderProgramBuffer, PixelShader, VertexShader, ShaderProgramState
-		ShaderParameter = 0x14, // Also called: RwShaderParameter
-		RenderableAssembly = 0x15,
-		Debug = 0x16, // Also called: RwDebug
-		KdTree = 0x17,
-		VoiceHierarchy = 0x18,
-		Snr = 0x19,
-		InterpreterData = 0x1A,
-		AttribSysSchema = 0x1B,
-		AttribSysVault = 0x1C,
-		EntryList = 0x1D,
-		AptData = 0x1E, // Also called: AptDataHeader, Flash
-		Popup = 0x1F, // Also called: GuiPopup
-		Font = 0x21,
-		LuaCode = 0x22,
-		InstanceList = 0x23,
-		CollisionMeshData = 0x24, // Also called: ClusteredMesh
-		IdList = 0x25, // Also called: ResourceIdList
-		InstanceCollisionList = 0x26,
-		Language = 0x27,
-		SatNavTile = 0x28,
-		SatNavTileDirectory = 0x29,
-		Model = 0x2A, // Also called: VehicleModel, WheelModel, PropModel
-		ColourCube = 0x2B, // Also called: RwColourCube
-		HudMessage = 0x2C, // Also called: GuiHudMessage
-		HudMessageList = 0x2D,
-		HudMessageSequence = 0x2E,
-		HudMessageSequenceDictionary = 0x2F,
-		WorldPainter2D = 0x30, // Also called: World Painter 2D
-		PFXHookBundle = 0x31, // Also called: GuiPFXHook
-		ShaderTechnique = 0x32, // Also called: Shader
+        // Standard types, shared between games
+        Texture = 0x00, // Also called: RwRaster, PlaneTexture, TexturePage
+        Material = 0x01, // Also called: RwMaterial, MaterialAssembly
+        RenderableMesh = 0x02, // Also called: Renderable; likely deprecated
+        TextFile = 0x03,
+        DrawIndexParams = 0x04,
+        IndexBuffer = 0x05,
+        MeshState = 0x06,
+        VertexBuffer = 0x09,
+        VertexDescriptor = 0x0A, // Also called: RwVertexDesc
+        MaterialCRC32 = 0x0B, // Also called: RwMaterialCRC32
+        Renderable = 0x0C, // Also called: RwRenderable, GtRenderable
+        MaterialTechnique = 0x0D,
+        TextureState = 0x0E, // Also called: RwTextureState
+        MaterialState = 0x0F, // Also called: BlendState
+        DepthStencilState = 0x10,
+        RasterizerState = 0x11,
+        ShaderProgramBuffer = 0x12, // Also called: RwShaderProgramBuffer, PixelShader, VertexShader, ShaderProgramState
+        ShaderParameter = 0x14, // Also called: RwShaderParameter
+        RenderableAssembly = 0x15,
+        Debug = 0x16, // Also called: RwDebug
+        KdTree = 0x17,
+        VoiceHierarchy = 0x18,
+        Snr = 0x19,
+        InterpreterData = 0x1A,
+        AttribSysSchema = 0x1B,
+        AttribSysVault = 0x1C,
+        EntryList = 0x1D,
+        AptData = 0x1E, // Also called: AptDataHeader, Flash
+        Popup = 0x1F, // Also called: GuiPopup
+        Font = 0x21,
+        LuaCode = 0x22,
+        InstanceList = 0x23,
+        CollisionMeshData = 0x24, // Also called: ClusteredMesh
+        IdList = 0x25, // Also called: ResourceIdList
+        InstanceCollisionList = 0x26,
+        Language = 0x27,
+        SatNavTile = 0x28,
+        SatNavTileDirectory = 0x29,
+        Model = 0x2A, // Also called: VehicleModel, WheelModel, PropModel
+        ColourCube = 0x2B, // Also called: RwColourCube
+        HudMessage = 0x2C, // Also called: GuiHudMessage
+        HudMessageList = 0x2D,
+        HudMessageSequence = 0x2E,
+        HudMessageSequenceDictionary = 0x2F,
+        WorldPainter2D = 0x30, // Also called: World Painter 2D
+        PFXHookBundle = 0x31, // Also called: GuiPFXHook
+        ShaderTechnique = 0x32, // Also called: Shader
 
-		RawFile = 0x40, // Also called: RAW, File
-		ICETakeDictionary = 0x41, // Also called: ICEDictionary; base type: Dictionary
-		VideoData = 0x42,
-		PolygonSoupList = 0x43, // Also called: CollisionMeshData
-		CommsToolListDefinition = 0x45, // Also called: CommsToolDef
-		CommsToolList = 0x46, // Also called: CoomsToolInst
+        RawFile = 0x40, // Also called: RAW, File
+        ICETakeDictionary = 0x41, // Also called: ICEDictionary; base type: Dictionary
+        VideoData = 0x42,
+        PolygonSoupList = 0x43, // Also called: CollisionMeshData
+        CommsToolListDefinition = 0x45, // Also called: CommsToolDef
+        CommsToolList = 0x46, // Also called: CoomsToolInst
 
-		// DLC types?
-		BinaryFile = 0x50, // Also called: AlignedBinaryFile; used as base type
-		AnimationCollection = 0x51,
+        // DLC types?
+        BinaryFile = 0x50, // Also called: AlignedBinaryFile; used as base type
+        AnimationCollection = 0x51,
 
-		// Random type IDs from the Black builds, probably for testing
-		CharAnimBankFile = 0x2710, // Also called: Character Animation Bank Data
-		WeaponFile = 0x2711, // Also called: WEAPONDATA
-		VFXFile = 0x343E, // Also called: VFX Data
-		BearFile = 0x343F, // Also called: Bear Data
-		BkPropInstanceList = 0x3A98,
+        // Random type IDs from the Black builds, probably for testing
+        CharAnimBankFile = 0x2710, // Also called: Character Animation Bank Data
+        WeaponFile = 0x2711, // Also called: WEAPONDATA
+        VFXFile = 0x343E, // Also called: VFX Data
+        BearFile = 0x343F, // Also called: Bear Data
+        BkPropInstanceList = 0x3A98,
 
-		Registry = 0xA000,
+        Registry = 0xA000,
 
-		// Sound-related types
-		GenericRwacWaveContent = 0xA020, // Also called: Generic Wave Content
-		GinsuWaveContent = 0xA021, // Also called: Ginsu Wave Content
-		AemsBank = 0xA022, // Also called: AEMS Bank
-		Csis = 0xA023, // Also called: CSIS
-		Nicotine = 0xA024, // Also called: Nicotine Map
-		Splicer = 0xA025, // Also called: Splicer Data
-		FreqContent = 0xA026,
-		VoiceHierarchyCollection = 0xA027,
-		GenericRwacReverbIRContent = 0xA028,
-		SnapshotData = 0xA029, // Also called: Snapshot Data
+        // Sound-related types
+        GenericRwacWaveContent = 0xA020, // Also called: Generic Wave Content
+        GinsuWaveContent = 0xA021, // Also called: Ginsu Wave Content
+        AemsBank = 0xA022, // Also called: AEMS Bank
+        Csis = 0xA023, // Also called: CSIS
+        Nicotine = 0xA024, // Also called: Nicotine Map
+        Splicer = 0xA025, // Also called: Splicer Data
+        FreqContent = 0xA026,
+        VoiceHierarchyCollection = 0xA027,
+        GenericRwacReverbIRContent = 0xA028,
+        SnapshotData = 0xA029, // Also called: Snapshot Data
 
-		ZoneList = 0xB000,
+        ZoneList = 0xB000,
 
-		// Game-specific types - Burnout Paradise
-		LoopModel = 0x10000,
-		AISections = 0x10001, // Also called: AIMapData
-		TrafficData = 0x10002,
-		TriggerData = 0x10003, // Also called: Trigger
-		DeformationModel = 0x10004,
-		VehicleList = 0x10005,
-		GraphicsSpec = 0x10006, // Also called: VehicleGraphics
-		PhysicsSpec = 0x10007,
-		ParticleDescriptionCollection = 0x10008,
-		WheelList = 0x10009,
-		WheelGraphicsSpec = 0x1000A, // Also called: WheelGraphics; base type: GraphicsSpec
-		TextureNameMap = 0x1000B,
-		ICEList = 0x1000C,
-		ICEData = 0x1000D, // Also called: ICE
-		ProgressionData = 0x1000E, // Also called: Progression
-		PropPhysics = 0x1000F,
-		PropGraphicsList = 0x10010,
-		PropInstanceData = 0x10011, // Also called: PropInstances
-		BrnEnvironmentKeyframe = 0x10012, // Base type: Keyframe
-		BrnEnvironmentTimeLine = 0x10013, // Base type: TimeLine
-		BrnEnvironmentDictionary = 0x10014, // Base type: Dictionary
-		GraphicsStub = 0x10015, // Also called: TrafficStub, TrafficGraphicsStub
-		StaticSoundMap = 0x10016,
-		StreetData = 0x10018,
-		VFXMeshCollection = 0x10019, // Also called: BrnVFXMeshCollection
-		MassiveLookupTable = 0x1001A,
-		VFXPropCollection = 0x1001B,
-		StreamedDeformation = 0x1001C, // Also called: StreamedDeformationSpec
-		ParticleDescription = 0x1001D,
-		PlayerCarColours = 0x1001E,
-		ChallengeList = 0x1001F,
-		FlaptFile = 0x10020,
-		ProfileUpgrade = 0x10021,
-		VehicleAnimation = 0x10023,
-		BodypartRemapData = 0x10024, // Also called: BodyPartRemapping
-		LUAList = 0x10025, // Also called: LUAInst
-		LUAScript = 0x10026,
+        // Game-specific types - Burnout Paradise
+        LoopModel = 0x10000,
+        AISections = 0x10001, // Also called: AIMapData
+        TrafficData = 0x10002,
+        TriggerData = 0x10003, // Also called: Trigger
+        DeformationModel = 0x10004,
+        VehicleList = 0x10005,
+        GraphicsSpec = 0x10006, // Also called: VehicleGraphics
+        PhysicsSpec = 0x10007,
+        ParticleDescriptionCollection = 0x10008,
+        WheelList = 0x10009,
+        WheelGraphicsSpec = 0x1000A, // Also called: WheelGraphics; base type: GraphicsSpec
+        TextureNameMap = 0x1000B,
+        ICEList = 0x1000C,
+        ICEData = 0x1000D, // Also called: ICE
+        ProgressionData = 0x1000E, // Also called: Progression
+        PropPhysics = 0x1000F,
+        PropGraphicsList = 0x10010,
+        PropInstanceData = 0x10011, // Also called: PropInstances
+        BrnEnvironmentKeyframe = 0x10012, // Base type: Keyframe
+        BrnEnvironmentTimeLine = 0x10013, // Base type: TimeLine
+        BrnEnvironmentDictionary = 0x10014, // Base type: Dictionary
+        GraphicsStub = 0x10015, // Also called: TrafficStub, TrafficGraphicsStub
+        StaticSoundMap = 0x10016,
+        StreetData = 0x10018,
+        VFXMeshCollection = 0x10019, // Also called: BrnVFXMeshCollection
+        MassiveLookupTable = 0x1001A,
+        VFXPropCollection = 0x1001B,
+        StreamedDeformation = 0x1001C, // Also called: StreamedDeformationSpec
+        ParticleDescription = 0x1001D,
+        PlayerCarColours = 0x1001E,
+        ChallengeList = 0x1001F,
+        FlaptFile = 0x10020,
+        ProfileUpgrade = 0x10021,
+        VehicleAnimation = 0x10023,
+        BodypartRemapData = 0x10024, // Also called: BodyPartRemapping
+        LUAList = 0x10025, // Also called: LUAInst
+        LUAScript = 0x10026,
 
-		// Game-specific types - Black 360/Black 2
-		BkSoundWeapon = 0x11000, // Also called: SoundWeapon Data
-		BkSoundGunsu = 0x11001, // Also called: SoundGunsu Data
-		BkSoundBulletImpact = 0x11002, // Also called: SoundBulletImpact Data
-		BkSoundBulletImpactList = 0x11003, // Also called: SoundBulletImpactList
-		BkSoundBulletImpactStream = 0x11004,  // Also called: SoundBulletImpactStream Data
+        // Game-specific types - Black 360/Black 2
+        BkSoundWeapon = 0x11000, // Also called: SoundWeapon Data
+        BkSoundGunsu = 0x11001, // Also called: SoundGunsu Data
+        BkSoundBulletImpact = 0x11002, // Also called: SoundBulletImpact Data
+        BkSoundBulletImpactList = 0x11003, // Also called: SoundBulletImpactList
+        BkSoundBulletImpactStream = 0x11004,  // Also called: SoundBulletImpactStream Data
 
-		Invalid = 0x99999
+        Invalid = 0x99999
     }
 }

--- a/BundleFormat/Extensions.cs
+++ b/BundleFormat/Extensions.cs
@@ -104,15 +104,15 @@ namespace BundleFormat
             return false;
         }
 
-		public static void Align(this BinaryWriter self, byte alignment)
-		{
-			self.BaseStream.Position = alignment * ((self.BaseStream.Position + (alignment - 1)) / alignment);
-			self.BaseStream.Position--;
-			self.Write((byte)0);
+        public static void Align(this BinaryWriter self, byte alignment)
+        {
+            self.BaseStream.Position = alignment * ((self.BaseStream.Position + (alignment - 1)) / alignment);
+            self.BaseStream.Position--;
+            self.Write((byte)0);
 
-			/*long currentOffset = self.BaseStream.Position;
-			for (int i = 0; i < (alignment - (currentOffset % alignment)); i++)
-				self.Write((byte)0);*/
-		}
+            /*long currentOffset = self.BaseStream.Position;
+            for (int i = 0; i < (alignment - (currentOffset % alignment)); i++)
+                self.Write((byte)0);*/
+        }
     }
 }

--- a/BundleManager/EntryEditor.Designer.cs
+++ b/BundleManager/EntryEditor.Designer.cs
@@ -30,289 +30,289 @@ namespace BundleManager
         /// </summary>
         private void InitializeComponent()
         {
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(EntryEditor));
-			this.tabList = new System.Windows.Forms.TabControl();
-			this.tabInfo = new System.Windows.Forms.TabPage();
-			this.txtInfo = new System.Windows.Forms.TextBox();
-			this.tabHeader = new System.Windows.Forms.TabPage();
-			this.hexData = new HexEditor.HexView();
-			this.tabBody = new System.Windows.Forms.TabPage();
-			this.hexExtraData = new HexEditor.HexView();
-			this.lblLoading = new System.Windows.Forms.Label();
-			this.mnuBar = new System.Windows.Forms.MenuStrip();
-			this.editStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.editHashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.binaryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.importHeaderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.exportHeaderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
-			this.importBodyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.exportBodyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.imageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.exportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.importToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.stsMain = new System.Windows.Forms.StatusStrip();
-			this.pbMain = new System.Windows.Forms.ProgressBar();
-			this.pboImage = new System.Windows.Forms.PictureBox();
-			this.tabList.SuspendLayout();
-			this.tabInfo.SuspendLayout();
-			this.tabHeader.SuspendLayout();
-			this.tabBody.SuspendLayout();
-			this.mnuBar.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.pboImage)).BeginInit();
-			this.SuspendLayout();
-			// 
-			// tabList
-			// 
-			this.tabList.Controls.Add(this.tabInfo);
-			this.tabList.Controls.Add(this.tabHeader);
-			this.tabList.Controls.Add(this.tabBody);
-			this.tabList.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.tabList.Location = new System.Drawing.Point(0, 0);
-			this.tabList.Name = "tabList";
-			this.tabList.SelectedIndex = 0;
-			this.tabList.Size = new System.Drawing.Size(624, 419);
-			this.tabList.TabIndex = 0;
-			this.tabList.SelectedIndexChanged += new System.EventHandler(this.tabList_SelectedIndexChanged);
-			// 
-			// tabInfo
-			// 
-			this.tabInfo.Controls.Add(this.txtInfo);
-			this.tabInfo.Location = new System.Drawing.Point(4, 22);
-			this.tabInfo.Name = "tabInfo";
-			this.tabInfo.Size = new System.Drawing.Size(616, 393);
-			this.tabInfo.TabIndex = 3;
-			this.tabInfo.Text = "Info";
-			this.tabInfo.UseVisualStyleBackColor = true;
-			// 
-			// txtInfo
-			// 
-			this.txtInfo.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(EntryEditor));
+            this.tabList = new System.Windows.Forms.TabControl();
+            this.tabInfo = new System.Windows.Forms.TabPage();
+            this.txtInfo = new System.Windows.Forms.TextBox();
+            this.tabHeader = new System.Windows.Forms.TabPage();
+            this.hexData = new HexEditor.HexView();
+            this.tabBody = new System.Windows.Forms.TabPage();
+            this.hexExtraData = new HexEditor.HexView();
+            this.lblLoading = new System.Windows.Forms.Label();
+            this.mnuBar = new System.Windows.Forms.MenuStrip();
+            this.editStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.editHashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.binaryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.importHeaderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportHeaderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+            this.importBodyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportBodyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.imageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.importToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.stsMain = new System.Windows.Forms.StatusStrip();
+            this.pbMain = new System.Windows.Forms.ProgressBar();
+            this.pboImage = new System.Windows.Forms.PictureBox();
+            this.tabList.SuspendLayout();
+            this.tabInfo.SuspendLayout();
+            this.tabHeader.SuspendLayout();
+            this.tabBody.SuspendLayout();
+            this.mnuBar.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pboImage)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // tabList
+            // 
+            this.tabList.Controls.Add(this.tabInfo);
+            this.tabList.Controls.Add(this.tabHeader);
+            this.tabList.Controls.Add(this.tabBody);
+            this.tabList.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tabList.Location = new System.Drawing.Point(0, 0);
+            this.tabList.Name = "tabList";
+            this.tabList.SelectedIndex = 0;
+            this.tabList.Size = new System.Drawing.Size(624, 419);
+            this.tabList.TabIndex = 0;
+            this.tabList.SelectedIndexChanged += new System.EventHandler(this.tabList_SelectedIndexChanged);
+            // 
+            // tabInfo
+            // 
+            this.tabInfo.Controls.Add(this.txtInfo);
+            this.tabInfo.Location = new System.Drawing.Point(4, 22);
+            this.tabInfo.Name = "tabInfo";
+            this.tabInfo.Size = new System.Drawing.Size(616, 393);
+            this.tabInfo.TabIndex = 3;
+            this.tabInfo.Text = "Info";
+            this.tabInfo.UseVisualStyleBackColor = true;
+            // 
+            // txtInfo
+            // 
+            this.txtInfo.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.txtInfo.BackColor = System.Drawing.SystemColors.ControlLightLight;
-			this.txtInfo.BorderStyle = System.Windows.Forms.BorderStyle.None;
-			this.txtInfo.Font = new System.Drawing.Font("Consolas", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.txtInfo.Location = new System.Drawing.Point(8, 3);
-			this.txtInfo.Multiline = true;
-			this.txtInfo.Name = "txtInfo";
-			this.txtInfo.ReadOnly = true;
-			this.txtInfo.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-			this.txtInfo.Size = new System.Drawing.Size(600, 387);
-			this.txtInfo.TabIndex = 1;
-			// 
-			// tabHeader
-			// 
-			this.tabHeader.Controls.Add(this.hexData);
-			this.tabHeader.Location = new System.Drawing.Point(4, 22);
-			this.tabHeader.Name = "tabHeader";
-			this.tabHeader.Padding = new System.Windows.Forms.Padding(3);
-			this.tabHeader.Size = new System.Drawing.Size(616, 393);
-			this.tabHeader.TabIndex = 0;
-			this.tabHeader.Text = "Header";
-			this.tabHeader.UseVisualStyleBackColor = true;
-			// 
-			// hexData
-			// 
-			this.hexData.AutoScroll = true;
-			this.hexData.BackColor = System.Drawing.Color.White;
-			this.hexData.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.hexData.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.hexData.Font = new System.Drawing.Font("Courier New", 10F);
-			this.hexData.HexData = null;
-			this.hexData.Location = new System.Drawing.Point(3, 3);
-			this.hexData.Name = "hexData";
-			this.hexData.Size = new System.Drawing.Size(610, 387);
-			this.hexData.TabIndex = 0;
-			// 
-			// tabBody
-			// 
-			this.tabBody.Controls.Add(this.hexExtraData);
-			this.tabBody.Location = new System.Drawing.Point(4, 22);
-			this.tabBody.Name = "tabBody";
-			this.tabBody.Padding = new System.Windows.Forms.Padding(3);
-			this.tabBody.Size = new System.Drawing.Size(616, 393);
-			this.tabBody.TabIndex = 2;
-			this.tabBody.Text = "Body";
-			this.tabBody.UseVisualStyleBackColor = true;
-			// 
-			// hexExtraData
-			// 
-			this.hexExtraData.AutoScroll = true;
-			this.hexExtraData.BackColor = System.Drawing.Color.White;
-			this.hexExtraData.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.hexExtraData.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.hexExtraData.Font = new System.Drawing.Font("Courier New", 10F);
-			this.hexExtraData.HexData = null;
-			this.hexExtraData.Location = new System.Drawing.Point(3, 3);
-			this.hexExtraData.Name = "hexExtraData";
-			this.hexExtraData.Size = new System.Drawing.Size(610, 387);
-			this.hexExtraData.TabIndex = 0;
-			// 
-			// lblLoading
-			// 
-			this.lblLoading.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.lblLoading.Font = new System.Drawing.Font("Courier New", 36F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.lblLoading.Location = new System.Drawing.Point(0, 0);
-			this.lblLoading.Name = "lblLoading";
-			this.lblLoading.Size = new System.Drawing.Size(624, 441);
-			this.lblLoading.TabIndex = 4;
-			this.lblLoading.Text = "Loading";
-			this.lblLoading.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// mnuBar
-			// 
-			this.mnuBar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.txtInfo.BackColor = System.Drawing.SystemColors.ControlLightLight;
+            this.txtInfo.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.txtInfo.Font = new System.Drawing.Font("Consolas", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.txtInfo.Location = new System.Drawing.Point(8, 3);
+            this.txtInfo.Multiline = true;
+            this.txtInfo.Name = "txtInfo";
+            this.txtInfo.ReadOnly = true;
+            this.txtInfo.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.txtInfo.Size = new System.Drawing.Size(600, 387);
+            this.txtInfo.TabIndex = 1;
+            // 
+            // tabHeader
+            // 
+            this.tabHeader.Controls.Add(this.hexData);
+            this.tabHeader.Location = new System.Drawing.Point(4, 22);
+            this.tabHeader.Name = "tabHeader";
+            this.tabHeader.Padding = new System.Windows.Forms.Padding(3);
+            this.tabHeader.Size = new System.Drawing.Size(616, 393);
+            this.tabHeader.TabIndex = 0;
+            this.tabHeader.Text = "Header";
+            this.tabHeader.UseVisualStyleBackColor = true;
+            // 
+            // hexData
+            // 
+            this.hexData.AutoScroll = true;
+            this.hexData.BackColor = System.Drawing.Color.White;
+            this.hexData.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.hexData.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.hexData.Font = new System.Drawing.Font("Courier New", 10F);
+            this.hexData.HexData = null;
+            this.hexData.Location = new System.Drawing.Point(3, 3);
+            this.hexData.Name = "hexData";
+            this.hexData.Size = new System.Drawing.Size(610, 387);
+            this.hexData.TabIndex = 0;
+            // 
+            // tabBody
+            // 
+            this.tabBody.Controls.Add(this.hexExtraData);
+            this.tabBody.Location = new System.Drawing.Point(4, 22);
+            this.tabBody.Name = "tabBody";
+            this.tabBody.Padding = new System.Windows.Forms.Padding(3);
+            this.tabBody.Size = new System.Drawing.Size(616, 393);
+            this.tabBody.TabIndex = 2;
+            this.tabBody.Text = "Body";
+            this.tabBody.UseVisualStyleBackColor = true;
+            // 
+            // hexExtraData
+            // 
+            this.hexExtraData.AutoScroll = true;
+            this.hexExtraData.BackColor = System.Drawing.Color.White;
+            this.hexExtraData.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.hexExtraData.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.hexExtraData.Font = new System.Drawing.Font("Courier New", 10F);
+            this.hexExtraData.HexData = null;
+            this.hexExtraData.Location = new System.Drawing.Point(3, 3);
+            this.hexExtraData.Name = "hexExtraData";
+            this.hexExtraData.Size = new System.Drawing.Size(610, 387);
+            this.hexExtraData.TabIndex = 0;
+            // 
+            // lblLoading
+            // 
+            this.lblLoading.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblLoading.Font = new System.Drawing.Font("Courier New", 36F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblLoading.Location = new System.Drawing.Point(0, 0);
+            this.lblLoading.Name = "lblLoading";
+            this.lblLoading.Size = new System.Drawing.Size(624, 441);
+            this.lblLoading.TabIndex = 4;
+            this.lblLoading.Text = "Loading";
+            this.lblLoading.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // mnuBar
+            // 
+            this.mnuBar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.binaryToolStripMenuItem,
-			this.editStripMenuItem,
+            this.editStripMenuItem,
             this.imageToolStripMenuItem});
-			this.mnuBar.Location = new System.Drawing.Point(0, 0);
-			this.mnuBar.Name = "mnuBar";
-			this.mnuBar.Size = new System.Drawing.Size(624, 24);
-			this.mnuBar.TabIndex = 6;
-			this.mnuBar.Text = "menuStrip1";
-			// 
-			//editStripMenuItem
-			// 
-			this.editStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.editHashToolStripMenuItem});
-			this.editStripMenuItem.Name = "editStripMenuItem";
-			this.editStripMenuItem.Size = new System.Drawing.Size(52, 20);
-			this.editStripMenuItem.Text = "Edit";
-			// 
-			// editHashToolStripMenuItem
-			// 
-			this.editHashToolStripMenuItem.Name = "editHashToolStripMenuItem";
-			this.editHashToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
-			this.editHashToolStripMenuItem.Text = "Edit ID";
-			this.editHashToolStripMenuItem.Click += new System.EventHandler(this.editId_Click);
-			// 
-			// binaryToolStripMenuItem
-			// 
-			this.binaryToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.mnuBar.Location = new System.Drawing.Point(0, 0);
+            this.mnuBar.Name = "mnuBar";
+            this.mnuBar.Size = new System.Drawing.Size(624, 24);
+            this.mnuBar.TabIndex = 6;
+            this.mnuBar.Text = "menuStrip1";
+            // 
+            //editStripMenuItem
+            // 
+            this.editStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.editHashToolStripMenuItem});
+            this.editStripMenuItem.Name = "editStripMenuItem";
+            this.editStripMenuItem.Size = new System.Drawing.Size(52, 20);
+            this.editStripMenuItem.Text = "Edit";
+            // 
+            // editHashToolStripMenuItem
+            // 
+            this.editHashToolStripMenuItem.Name = "editHashToolStripMenuItem";
+            this.editHashToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
+            this.editHashToolStripMenuItem.Text = "Edit ID";
+            this.editHashToolStripMenuItem.Click += new System.EventHandler(this.editId_Click);
+            // 
+            // binaryToolStripMenuItem
+            // 
+            this.binaryToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.importHeaderToolStripMenuItem,
             this.exportHeaderToolStripMenuItem,
             this.toolStripMenuItem1,
             this.importBodyToolStripMenuItem,
             this.exportBodyToolStripMenuItem});
-			this.binaryToolStripMenuItem.Name = "binaryToolStripMenuItem";
-			this.binaryToolStripMenuItem.Size = new System.Drawing.Size(52, 20);
-			this.binaryToolStripMenuItem.Text = "Binary";
-			// 
-			// importHeaderToolStripMenuItem
-			// 
-			this.importHeaderToolStripMenuItem.Name = "importHeaderToolStripMenuItem";
-			this.importHeaderToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
-			this.importHeaderToolStripMenuItem.Text = "Import Header";
-			this.importHeaderToolStripMenuItem.Click += new System.EventHandler(this.importDataToolStripMenuItem_Click);
-			// 
-			// exportHeaderToolStripMenuItem
-			// 
-			this.exportHeaderToolStripMenuItem.Name = "exportHeaderToolStripMenuItem";
-			this.exportHeaderToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
-			this.exportHeaderToolStripMenuItem.Text = "Export Header";
-			this.exportHeaderToolStripMenuItem.Click += new System.EventHandler(this.exportDataToolStripMenuItem_Click);
-			// 
-			// toolStripMenuItem1
-			// 
-			this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-			this.toolStripMenuItem1.Size = new System.Drawing.Size(148, 6);
-			// 
-			// importBodyToolStripMenuItem
-			// 
-			this.importBodyToolStripMenuItem.Name = "importBodyToolStripMenuItem";
-			this.importBodyToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
-			this.importBodyToolStripMenuItem.Text = "Import Body";
-			this.importBodyToolStripMenuItem.Click += new System.EventHandler(this.importExtraToolStripMenuItem_Click);
-			// 
-			// exportBodyToolStripMenuItem
-			// 
-			this.exportBodyToolStripMenuItem.Name = "exportBodyToolStripMenuItem";
-			this.exportBodyToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
-			this.exportBodyToolStripMenuItem.Text = "Export Body";
-			this.exportBodyToolStripMenuItem.Click += new System.EventHandler(this.exportExtraToolStripMenuItem_Click);
-			// 
-			// imageToolStripMenuItem
-			// 
-			this.imageToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.binaryToolStripMenuItem.Name = "binaryToolStripMenuItem";
+            this.binaryToolStripMenuItem.Size = new System.Drawing.Size(52, 20);
+            this.binaryToolStripMenuItem.Text = "Binary";
+            // 
+            // importHeaderToolStripMenuItem
+            // 
+            this.importHeaderToolStripMenuItem.Name = "importHeaderToolStripMenuItem";
+            this.importHeaderToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
+            this.importHeaderToolStripMenuItem.Text = "Import Header";
+            this.importHeaderToolStripMenuItem.Click += new System.EventHandler(this.importDataToolStripMenuItem_Click);
+            // 
+            // exportHeaderToolStripMenuItem
+            // 
+            this.exportHeaderToolStripMenuItem.Name = "exportHeaderToolStripMenuItem";
+            this.exportHeaderToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
+            this.exportHeaderToolStripMenuItem.Text = "Export Header";
+            this.exportHeaderToolStripMenuItem.Click += new System.EventHandler(this.exportDataToolStripMenuItem_Click);
+            // 
+            // toolStripMenuItem1
+            // 
+            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(148, 6);
+            // 
+            // importBodyToolStripMenuItem
+            // 
+            this.importBodyToolStripMenuItem.Name = "importBodyToolStripMenuItem";
+            this.importBodyToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
+            this.importBodyToolStripMenuItem.Text = "Import Body";
+            this.importBodyToolStripMenuItem.Click += new System.EventHandler(this.importExtraToolStripMenuItem_Click);
+            // 
+            // exportBodyToolStripMenuItem
+            // 
+            this.exportBodyToolStripMenuItem.Name = "exportBodyToolStripMenuItem";
+            this.exportBodyToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
+            this.exportBodyToolStripMenuItem.Text = "Export Body";
+            this.exportBodyToolStripMenuItem.Click += new System.EventHandler(this.exportExtraToolStripMenuItem_Click);
+            // 
+            // imageToolStripMenuItem
+            // 
+            this.imageToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.exportToolStripMenuItem,
             this.importToolStripMenuItem});
-			this.imageToolStripMenuItem.Name = "imageToolStripMenuItem";
-			this.imageToolStripMenuItem.Size = new System.Drawing.Size(52, 20);
-			this.imageToolStripMenuItem.Text = "Image";
-			// 
-			// exportToolStripMenuItem
-			// 
-			this.exportToolStripMenuItem.Name = "exportToolStripMenuItem";
-			this.exportToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-			this.exportToolStripMenuItem.Text = "Export";
-			this.exportToolStripMenuItem.Click += new System.EventHandler(this.exportToolStripMenuItem_Click);
-			// 
-			// importToolStripMenuItem
-			// 
-			this.importToolStripMenuItem.Name = "importToolStripMenuItem";
-			this.importToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-			this.importToolStripMenuItem.Text = "Import (Legacy PC)";
-			this.importToolStripMenuItem.Click += new System.EventHandler(this.importToolStripMenuItem_Click);
-			// 
-			// stsMain
-			// 
-			this.stsMain.Location = new System.Drawing.Point(0, 419);
-			this.stsMain.Name = "stsMain";
-			this.stsMain.Size = new System.Drawing.Size(624, 22);
-			this.stsMain.TabIndex = 7;
-			// 
-			// pbMain
-			// 
-			this.pbMain.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            this.imageToolStripMenuItem.Name = "imageToolStripMenuItem";
+            this.imageToolStripMenuItem.Size = new System.Drawing.Size(52, 20);
+            this.imageToolStripMenuItem.Text = "Image";
+            // 
+            // exportToolStripMenuItem
+            // 
+            this.exportToolStripMenuItem.Name = "exportToolStripMenuItem";
+            this.exportToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.exportToolStripMenuItem.Text = "Export";
+            this.exportToolStripMenuItem.Click += new System.EventHandler(this.exportToolStripMenuItem_Click);
+            // 
+            // importToolStripMenuItem
+            // 
+            this.importToolStripMenuItem.Name = "importToolStripMenuItem";
+            this.importToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.importToolStripMenuItem.Text = "Import (Legacy PC)";
+            this.importToolStripMenuItem.Click += new System.EventHandler(this.importToolStripMenuItem_Click);
+            // 
+            // stsMain
+            // 
+            this.stsMain.Location = new System.Drawing.Point(0, 419);
+            this.stsMain.Name = "stsMain";
+            this.stsMain.Size = new System.Drawing.Size(624, 22);
+            this.stsMain.TabIndex = 7;
+            // 
+            // pbMain
+            // 
+            this.pbMain.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.pbMain.Location = new System.Drawing.Point(12, 384);
-			this.pbMain.MarqueeAnimationSpeed = 10;
-			this.pbMain.Name = "pbMain";
-			this.pbMain.Size = new System.Drawing.Size(600, 23);
-			this.pbMain.Style = System.Windows.Forms.ProgressBarStyle.Marquee;
-			this.pbMain.TabIndex = 8;
-			// 
-			// pboImage
-			// 
-			this.pboImage.BackColor = System.Drawing.Color.DarkGray;
-			this.pboImage.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.pboImage.Location = new System.Drawing.Point(0, 24);
-			this.pboImage.Name = "pboImage";
-			this.pboImage.Size = new System.Drawing.Size(624, 395);
-			this.pboImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-			this.pboImage.TabIndex = 9;
-			this.pboImage.TabStop = false;
-			// 
-			// EntryEditor
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(624, 441);
-			this.Controls.Add(this.pboImage);
-			this.Controls.Add(this.mnuBar);
-			this.Controls.Add(this.tabList);
-			this.Controls.Add(this.stsMain);
-			this.Controls.Add(this.pbMain);
-			this.Controls.Add(this.lblLoading);
-			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-			this.MainMenuStrip = this.mnuBar;
-			this.MinimizeBox = false;
-			this.MinimumSize = new System.Drawing.Size(300, 200);
-			this.Name = "EntryEditor";
-			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "EntryEditor";
-			this.Shown += new System.EventHandler(this.EntryEditor_Shown);
-			this.tabList.ResumeLayout(false);
-			this.tabInfo.ResumeLayout(false);
-			this.tabInfo.PerformLayout();
-			this.tabHeader.ResumeLayout(false);
-			this.tabBody.ResumeLayout(false);
-			this.mnuBar.ResumeLayout(false);
-			this.mnuBar.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.pboImage)).EndInit();
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.pbMain.Location = new System.Drawing.Point(12, 384);
+            this.pbMain.MarqueeAnimationSpeed = 10;
+            this.pbMain.Name = "pbMain";
+            this.pbMain.Size = new System.Drawing.Size(600, 23);
+            this.pbMain.Style = System.Windows.Forms.ProgressBarStyle.Marquee;
+            this.pbMain.TabIndex = 8;
+            // 
+            // pboImage
+            // 
+            this.pboImage.BackColor = System.Drawing.Color.DarkGray;
+            this.pboImage.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.pboImage.Location = new System.Drawing.Point(0, 24);
+            this.pboImage.Name = "pboImage";
+            this.pboImage.Size = new System.Drawing.Size(624, 395);
+            this.pboImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            this.pboImage.TabIndex = 9;
+            this.pboImage.TabStop = false;
+            // 
+            // EntryEditor
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(624, 441);
+            this.Controls.Add(this.pboImage);
+            this.Controls.Add(this.mnuBar);
+            this.Controls.Add(this.tabList);
+            this.Controls.Add(this.stsMain);
+            this.Controls.Add(this.pbMain);
+            this.Controls.Add(this.lblLoading);
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.MainMenuStrip = this.mnuBar;
+            this.MinimizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(300, 200);
+            this.Name = "EntryEditor";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "EntryEditor";
+            this.Shown += new System.EventHandler(this.EntryEditor_Shown);
+            this.tabList.ResumeLayout(false);
+            this.tabInfo.ResumeLayout(false);
+            this.tabInfo.PerformLayout();
+            this.tabHeader.ResumeLayout(false);
+            this.tabBody.ResumeLayout(false);
+            this.mnuBar.ResumeLayout(false);
+            this.mnuBar.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pboImage)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -323,10 +323,10 @@ namespace BundleManager
         private System.Windows.Forms.TabPage tabBody;
         private System.Windows.Forms.Label lblLoading;
         private System.Windows.Forms.MenuStrip mnuBar;
-		private System.Windows.Forms.ToolStripMenuItem editStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem editHashToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem binaryToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem importHeaderToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem editStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem editHashToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem binaryToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem importHeaderToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem exportHeaderToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripMenuItem1;
         private System.Windows.Forms.ToolStripMenuItem importBodyToolStripMenuItem;

--- a/BundleManager/EntryEditor.Designer.cs
+++ b/BundleManager/EntryEditor.Designer.cs
@@ -30,297 +30,297 @@ namespace BundleManager
         /// </summary>
         private void InitializeComponent()
         {
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(EntryEditor));
-			this.tabList = new System.Windows.Forms.TabControl();
-			this.tabInfo = new System.Windows.Forms.TabPage();
-			this.txtInfo = new System.Windows.Forms.TextBox();
-			this.tabHeader = new System.Windows.Forms.TabPage();
-			this.hexData = new HexEditor.HexView();
-			this.tabBody = new System.Windows.Forms.TabPage();
-			this.hexExtraData = new HexEditor.HexView();
-			this.lblLoading = new System.Windows.Forms.Label();
-			this.mnuBar = new System.Windows.Forms.MenuStrip();
-			this.editStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.editHashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.calcLookupHashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.binaryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.importHeaderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.exportHeaderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
-			this.importBodyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.exportBodyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.imageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.exportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.importToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.stsMain = new System.Windows.Forms.StatusStrip();
-			this.pbMain = new System.Windows.Forms.ProgressBar();
-			this.pboImage = new System.Windows.Forms.PictureBox();
-			this.tabList.SuspendLayout();
-			this.tabInfo.SuspendLayout();
-			this.tabHeader.SuspendLayout();
-			this.tabBody.SuspendLayout();
-			this.mnuBar.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.pboImage)).BeginInit();
-			this.SuspendLayout();
-			// 
-			// tabList
-			// 
-			this.tabList.Controls.Add(this.tabInfo);
-			this.tabList.Controls.Add(this.tabHeader);
-			this.tabList.Controls.Add(this.tabBody);
-			this.tabList.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.tabList.Location = new System.Drawing.Point(0, 0);
-			this.tabList.Name = "tabList";
-			this.tabList.SelectedIndex = 0;
-			this.tabList.Size = new System.Drawing.Size(624, 419);
-			this.tabList.TabIndex = 0;
-			this.tabList.SelectedIndexChanged += new System.EventHandler(this.tabList_SelectedIndexChanged);
-			// 
-			// tabInfo
-			// 
-			this.tabInfo.Controls.Add(this.txtInfo);
-			this.tabInfo.Location = new System.Drawing.Point(4, 22);
-			this.tabInfo.Name = "tabInfo";
-			this.tabInfo.Size = new System.Drawing.Size(616, 393);
-			this.tabInfo.TabIndex = 3;
-			this.tabInfo.Text = "Info";
-			this.tabInfo.UseVisualStyleBackColor = true;
-			// 
-			// txtInfo
-			// 
-			this.txtInfo.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(EntryEditor));
+            this.tabList = new System.Windows.Forms.TabControl();
+            this.tabInfo = new System.Windows.Forms.TabPage();
+            this.txtInfo = new System.Windows.Forms.TextBox();
+            this.tabHeader = new System.Windows.Forms.TabPage();
+            this.hexData = new HexEditor.HexView();
+            this.tabBody = new System.Windows.Forms.TabPage();
+            this.hexExtraData = new HexEditor.HexView();
+            this.lblLoading = new System.Windows.Forms.Label();
+            this.mnuBar = new System.Windows.Forms.MenuStrip();
+            this.editStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.editHashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.calcLookupHashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.binaryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.importHeaderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportHeaderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+            this.importBodyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportBodyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.imageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.importToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.stsMain = new System.Windows.Forms.StatusStrip();
+            this.pbMain = new System.Windows.Forms.ProgressBar();
+            this.pboImage = new System.Windows.Forms.PictureBox();
+            this.tabList.SuspendLayout();
+            this.tabInfo.SuspendLayout();
+            this.tabHeader.SuspendLayout();
+            this.tabBody.SuspendLayout();
+            this.mnuBar.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pboImage)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // tabList
+            // 
+            this.tabList.Controls.Add(this.tabInfo);
+            this.tabList.Controls.Add(this.tabHeader);
+            this.tabList.Controls.Add(this.tabBody);
+            this.tabList.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tabList.Location = new System.Drawing.Point(0, 0);
+            this.tabList.Name = "tabList";
+            this.tabList.SelectedIndex = 0;
+            this.tabList.Size = new System.Drawing.Size(624, 419);
+            this.tabList.TabIndex = 0;
+            this.tabList.SelectedIndexChanged += new System.EventHandler(this.tabList_SelectedIndexChanged);
+            // 
+            // tabInfo
+            // 
+            this.tabInfo.Controls.Add(this.txtInfo);
+            this.tabInfo.Location = new System.Drawing.Point(4, 22);
+            this.tabInfo.Name = "tabInfo";
+            this.tabInfo.Size = new System.Drawing.Size(616, 393);
+            this.tabInfo.TabIndex = 3;
+            this.tabInfo.Text = "Info";
+            this.tabInfo.UseVisualStyleBackColor = true;
+            // 
+            // txtInfo
+            // 
+            this.txtInfo.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.txtInfo.BackColor = System.Drawing.SystemColors.ControlLightLight;
-			this.txtInfo.BorderStyle = System.Windows.Forms.BorderStyle.None;
-			this.txtInfo.Font = new System.Drawing.Font("Consolas", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.txtInfo.Location = new System.Drawing.Point(8, 3);
-			this.txtInfo.Multiline = true;
-			this.txtInfo.Name = "txtInfo";
-			this.txtInfo.ReadOnly = true;
-			this.txtInfo.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-			this.txtInfo.Size = new System.Drawing.Size(600, 387);
-			this.txtInfo.TabIndex = 1;
-			// 
-			// tabHeader
-			// 
-			this.tabHeader.Controls.Add(this.hexData);
-			this.tabHeader.Location = new System.Drawing.Point(4, 22);
-			this.tabHeader.Name = "tabHeader";
-			this.tabHeader.Padding = new System.Windows.Forms.Padding(3);
-			this.tabHeader.Size = new System.Drawing.Size(616, 393);
-			this.tabHeader.TabIndex = 0;
-			this.tabHeader.Text = "Header";
-			this.tabHeader.UseVisualStyleBackColor = true;
-			// 
-			// hexData
-			// 
-			this.hexData.AutoScroll = true;
-			this.hexData.BackColor = System.Drawing.Color.White;
-			this.hexData.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.hexData.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.hexData.Font = new System.Drawing.Font("Courier New", 10F);
-			this.hexData.HexData = null;
-			this.hexData.Location = new System.Drawing.Point(3, 3);
-			this.hexData.Name = "hexData";
-			this.hexData.Size = new System.Drawing.Size(610, 387);
-			this.hexData.TabIndex = 0;
-			// 
-			// tabBody
-			// 
-			this.tabBody.Controls.Add(this.hexExtraData);
-			this.tabBody.Location = new System.Drawing.Point(4, 22);
-			this.tabBody.Name = "tabBody";
-			this.tabBody.Padding = new System.Windows.Forms.Padding(3);
-			this.tabBody.Size = new System.Drawing.Size(616, 393);
-			this.tabBody.TabIndex = 2;
-			this.tabBody.Text = "Body";
-			this.tabBody.UseVisualStyleBackColor = true;
-			// 
-			// hexExtraData
-			// 
-			this.hexExtraData.AutoScroll = true;
-			this.hexExtraData.BackColor = System.Drawing.Color.White;
-			this.hexExtraData.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.hexExtraData.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.hexExtraData.Font = new System.Drawing.Font("Courier New", 10F);
-			this.hexExtraData.HexData = null;
-			this.hexExtraData.Location = new System.Drawing.Point(3, 3);
-			this.hexExtraData.Name = "hexExtraData";
-			this.hexExtraData.Size = new System.Drawing.Size(610, 387);
-			this.hexExtraData.TabIndex = 0;
-			// 
-			// lblLoading
-			// 
-			this.lblLoading.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.lblLoading.Font = new System.Drawing.Font("Courier New", 36F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.lblLoading.Location = new System.Drawing.Point(0, 0);
-			this.lblLoading.Name = "lblLoading";
-			this.lblLoading.Size = new System.Drawing.Size(624, 441);
-			this.lblLoading.TabIndex = 4;
-			this.lblLoading.Text = "Loading";
-			this.lblLoading.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// mnuBar
-			// 
-			this.mnuBar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.txtInfo.BackColor = System.Drawing.SystemColors.ControlLightLight;
+            this.txtInfo.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.txtInfo.Font = new System.Drawing.Font("Consolas", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.txtInfo.Location = new System.Drawing.Point(8, 3);
+            this.txtInfo.Multiline = true;
+            this.txtInfo.Name = "txtInfo";
+            this.txtInfo.ReadOnly = true;
+            this.txtInfo.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.txtInfo.Size = new System.Drawing.Size(600, 387);
+            this.txtInfo.TabIndex = 1;
+            // 
+            // tabHeader
+            // 
+            this.tabHeader.Controls.Add(this.hexData);
+            this.tabHeader.Location = new System.Drawing.Point(4, 22);
+            this.tabHeader.Name = "tabHeader";
+            this.tabHeader.Padding = new System.Windows.Forms.Padding(3);
+            this.tabHeader.Size = new System.Drawing.Size(616, 393);
+            this.tabHeader.TabIndex = 0;
+            this.tabHeader.Text = "Header";
+            this.tabHeader.UseVisualStyleBackColor = true;
+            // 
+            // hexData
+            // 
+            this.hexData.AutoScroll = true;
+            this.hexData.BackColor = System.Drawing.Color.White;
+            this.hexData.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.hexData.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.hexData.Font = new System.Drawing.Font("Courier New", 10F);
+            this.hexData.HexData = null;
+            this.hexData.Location = new System.Drawing.Point(3, 3);
+            this.hexData.Name = "hexData";
+            this.hexData.Size = new System.Drawing.Size(610, 387);
+            this.hexData.TabIndex = 0;
+            // 
+            // tabBody
+            // 
+            this.tabBody.Controls.Add(this.hexExtraData);
+            this.tabBody.Location = new System.Drawing.Point(4, 22);
+            this.tabBody.Name = "tabBody";
+            this.tabBody.Padding = new System.Windows.Forms.Padding(3);
+            this.tabBody.Size = new System.Drawing.Size(616, 393);
+            this.tabBody.TabIndex = 2;
+            this.tabBody.Text = "Body";
+            this.tabBody.UseVisualStyleBackColor = true;
+            // 
+            // hexExtraData
+            // 
+            this.hexExtraData.AutoScroll = true;
+            this.hexExtraData.BackColor = System.Drawing.Color.White;
+            this.hexExtraData.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.hexExtraData.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.hexExtraData.Font = new System.Drawing.Font("Courier New", 10F);
+            this.hexExtraData.HexData = null;
+            this.hexExtraData.Location = new System.Drawing.Point(3, 3);
+            this.hexExtraData.Name = "hexExtraData";
+            this.hexExtraData.Size = new System.Drawing.Size(610, 387);
+            this.hexExtraData.TabIndex = 0;
+            // 
+            // lblLoading
+            // 
+            this.lblLoading.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblLoading.Font = new System.Drawing.Font("Courier New", 36F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblLoading.Location = new System.Drawing.Point(0, 0);
+            this.lblLoading.Name = "lblLoading";
+            this.lblLoading.Size = new System.Drawing.Size(624, 441);
+            this.lblLoading.TabIndex = 4;
+            this.lblLoading.Text = "Loading";
+            this.lblLoading.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // mnuBar
+            // 
+            this.mnuBar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.binaryToolStripMenuItem,
-			this.editStripMenuItem,
+            this.editStripMenuItem,
             this.imageToolStripMenuItem});
-			this.mnuBar.Location = new System.Drawing.Point(0, 0);
-			this.mnuBar.Name = "mnuBar";
-			this.mnuBar.Size = new System.Drawing.Size(624, 24);
-			this.mnuBar.TabIndex = 6;
-			this.mnuBar.Text = "menuStrip1";
-			// 
-			//editStripMenuItem
-			// 
-			this.editStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.editHashToolStripMenuItem, this.calcLookupHashToolStripMenuItem});
-			this.editStripMenuItem.Name = "editStripMenuItem";
-			this.editStripMenuItem.Size = new System.Drawing.Size(52, 20);
-			this.editStripMenuItem.Text = "Edit";
-			// 
-			// editHashToolStripMenuItem
-			// 
-			this.editHashToolStripMenuItem.Name = "editHashToolStripMenuItem";
-			this.editHashToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
-			this.editHashToolStripMenuItem.Text = "Edit ID";
-			this.editHashToolStripMenuItem.Click += new System.EventHandler(this.editId_Click);
-			// 
-			// editHashToolStripMenuItem
-			// 
-			this.calcLookupHashToolStripMenuItem.Name = "calcLookupHashToolStripMenuItem";
-			this.calcLookupHashToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
-			this.calcLookupHashToolStripMenuItem.Text = "Calc Lookup8 Hash";
-			this.calcLookupHashToolStripMenuItem.Click += new System.EventHandler(this.calcLookup8_Click);
-			// 
-			// binaryToolStripMenuItem
-			// 
-			this.binaryToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.mnuBar.Location = new System.Drawing.Point(0, 0);
+            this.mnuBar.Name = "mnuBar";
+            this.mnuBar.Size = new System.Drawing.Size(624, 24);
+            this.mnuBar.TabIndex = 6;
+            this.mnuBar.Text = "menuStrip1";
+            // 
+            //editStripMenuItem
+            // 
+            this.editStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.editHashToolStripMenuItem, this.calcLookupHashToolStripMenuItem});
+            this.editStripMenuItem.Name = "editStripMenuItem";
+            this.editStripMenuItem.Size = new System.Drawing.Size(52, 20);
+            this.editStripMenuItem.Text = "Edit";
+            // 
+            // editHashToolStripMenuItem
+            // 
+            this.editHashToolStripMenuItem.Name = "editHashToolStripMenuItem";
+            this.editHashToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
+            this.editHashToolStripMenuItem.Text = "Edit ID";
+            this.editHashToolStripMenuItem.Click += new System.EventHandler(this.editId_Click);
+            // 
+            // editHashToolStripMenuItem
+            // 
+            this.calcLookupHashToolStripMenuItem.Name = "calcLookupHashToolStripMenuItem";
+            this.calcLookupHashToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
+            this.calcLookupHashToolStripMenuItem.Text = "Calc Lookup8 Hash";
+            this.calcLookupHashToolStripMenuItem.Click += new System.EventHandler(this.calcLookup8_Click);
+            // 
+            // binaryToolStripMenuItem
+            // 
+            this.binaryToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.importHeaderToolStripMenuItem,
             this.exportHeaderToolStripMenuItem,
             this.toolStripMenuItem1,
             this.importBodyToolStripMenuItem,
             this.exportBodyToolStripMenuItem});
-			this.binaryToolStripMenuItem.Name = "binaryToolStripMenuItem";
-			this.binaryToolStripMenuItem.Size = new System.Drawing.Size(52, 20);
-			this.binaryToolStripMenuItem.Text = "Binary";
-			// 
-			// importHeaderToolStripMenuItem
-			// 
-			this.importHeaderToolStripMenuItem.Name = "importHeaderToolStripMenuItem";
-			this.importHeaderToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
-			this.importHeaderToolStripMenuItem.Text = "Import Header";
-			this.importHeaderToolStripMenuItem.Click += new System.EventHandler(this.importDataToolStripMenuItem_Click);
-			// 
-			// exportHeaderToolStripMenuItem
-			// 
-			this.exportHeaderToolStripMenuItem.Name = "exportHeaderToolStripMenuItem";
-			this.exportHeaderToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
-			this.exportHeaderToolStripMenuItem.Text = "Export Header";
-			this.exportHeaderToolStripMenuItem.Click += new System.EventHandler(this.exportDataToolStripMenuItem_Click);
-			// 
-			// toolStripMenuItem1
-			// 
-			this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-			this.toolStripMenuItem1.Size = new System.Drawing.Size(148, 6);
-			// 
-			// importBodyToolStripMenuItem
-			// 
-			this.importBodyToolStripMenuItem.Name = "importBodyToolStripMenuItem";
-			this.importBodyToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
-			this.importBodyToolStripMenuItem.Text = "Import Body";
-			this.importBodyToolStripMenuItem.Click += new System.EventHandler(this.importExtraToolStripMenuItem_Click);
-			// 
-			// exportBodyToolStripMenuItem
-			// 
-			this.exportBodyToolStripMenuItem.Name = "exportBodyToolStripMenuItem";
-			this.exportBodyToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
-			this.exportBodyToolStripMenuItem.Text = "Export Body";
-			this.exportBodyToolStripMenuItem.Click += new System.EventHandler(this.exportExtraToolStripMenuItem_Click);
-			// 
-			// imageToolStripMenuItem
-			// 
-			this.imageToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.binaryToolStripMenuItem.Name = "binaryToolStripMenuItem";
+            this.binaryToolStripMenuItem.Size = new System.Drawing.Size(52, 20);
+            this.binaryToolStripMenuItem.Text = "Binary";
+            // 
+            // importHeaderToolStripMenuItem
+            // 
+            this.importHeaderToolStripMenuItem.Name = "importHeaderToolStripMenuItem";
+            this.importHeaderToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
+            this.importHeaderToolStripMenuItem.Text = "Import Header";
+            this.importHeaderToolStripMenuItem.Click += new System.EventHandler(this.importDataToolStripMenuItem_Click);
+            // 
+            // exportHeaderToolStripMenuItem
+            // 
+            this.exportHeaderToolStripMenuItem.Name = "exportHeaderToolStripMenuItem";
+            this.exportHeaderToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
+            this.exportHeaderToolStripMenuItem.Text = "Export Header";
+            this.exportHeaderToolStripMenuItem.Click += new System.EventHandler(this.exportDataToolStripMenuItem_Click);
+            // 
+            // toolStripMenuItem1
+            // 
+            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(148, 6);
+            // 
+            // importBodyToolStripMenuItem
+            // 
+            this.importBodyToolStripMenuItem.Name = "importBodyToolStripMenuItem";
+            this.importBodyToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
+            this.importBodyToolStripMenuItem.Text = "Import Body";
+            this.importBodyToolStripMenuItem.Click += new System.EventHandler(this.importExtraToolStripMenuItem_Click);
+            // 
+            // exportBodyToolStripMenuItem
+            // 
+            this.exportBodyToolStripMenuItem.Name = "exportBodyToolStripMenuItem";
+            this.exportBodyToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
+            this.exportBodyToolStripMenuItem.Text = "Export Body";
+            this.exportBodyToolStripMenuItem.Click += new System.EventHandler(this.exportExtraToolStripMenuItem_Click);
+            // 
+            // imageToolStripMenuItem
+            // 
+            this.imageToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.exportToolStripMenuItem,
             this.importToolStripMenuItem});
-			this.imageToolStripMenuItem.Name = "imageToolStripMenuItem";
-			this.imageToolStripMenuItem.Size = new System.Drawing.Size(52, 20);
-			this.imageToolStripMenuItem.Text = "Image";
-			// 
-			// exportToolStripMenuItem
-			// 
-			this.exportToolStripMenuItem.Name = "exportToolStripMenuItem";
-			this.exportToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-			this.exportToolStripMenuItem.Text = "Export";
-			this.exportToolStripMenuItem.Click += new System.EventHandler(this.exportToolStripMenuItem_Click);
-			// 
-			// importToolStripMenuItem
-			// 
-			this.importToolStripMenuItem.Name = "importToolStripMenuItem";
-			this.importToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-			this.importToolStripMenuItem.Text = "Import (Legacy PC)";
-			this.importToolStripMenuItem.Click += new System.EventHandler(this.importToolStripMenuItem_Click);
-			// 
-			// stsMain
-			// 
-			this.stsMain.Location = new System.Drawing.Point(0, 419);
-			this.stsMain.Name = "stsMain";
-			this.stsMain.Size = new System.Drawing.Size(624, 22);
-			this.stsMain.TabIndex = 7;
-			// 
-			// pbMain
-			// 
-			this.pbMain.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            this.imageToolStripMenuItem.Name = "imageToolStripMenuItem";
+            this.imageToolStripMenuItem.Size = new System.Drawing.Size(52, 20);
+            this.imageToolStripMenuItem.Text = "Image";
+            // 
+            // exportToolStripMenuItem
+            // 
+            this.exportToolStripMenuItem.Name = "exportToolStripMenuItem";
+            this.exportToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.exportToolStripMenuItem.Text = "Export";
+            this.exportToolStripMenuItem.Click += new System.EventHandler(this.exportToolStripMenuItem_Click);
+            // 
+            // importToolStripMenuItem
+            // 
+            this.importToolStripMenuItem.Name = "importToolStripMenuItem";
+            this.importToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.importToolStripMenuItem.Text = "Import (Legacy PC)";
+            this.importToolStripMenuItem.Click += new System.EventHandler(this.importToolStripMenuItem_Click);
+            // 
+            // stsMain
+            // 
+            this.stsMain.Location = new System.Drawing.Point(0, 419);
+            this.stsMain.Name = "stsMain";
+            this.stsMain.Size = new System.Drawing.Size(624, 22);
+            this.stsMain.TabIndex = 7;
+            // 
+            // pbMain
+            // 
+            this.pbMain.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.pbMain.Location = new System.Drawing.Point(12, 384);
-			this.pbMain.MarqueeAnimationSpeed = 10;
-			this.pbMain.Name = "pbMain";
-			this.pbMain.Size = new System.Drawing.Size(600, 23);
-			this.pbMain.Style = System.Windows.Forms.ProgressBarStyle.Marquee;
-			this.pbMain.TabIndex = 8;
-			// 
-			// pboImage
-			// 
-			this.pboImage.BackColor = System.Drawing.Color.DarkGray;
-			this.pboImage.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.pboImage.Location = new System.Drawing.Point(0, 24);
-			this.pboImage.Name = "pboImage";
-			this.pboImage.Size = new System.Drawing.Size(624, 395);
-			this.pboImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-			this.pboImage.TabIndex = 9;
-			this.pboImage.TabStop = false;
-			// 
-			// EntryEditor
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(624, 441);
-			this.Controls.Add(this.pboImage);
-			this.Controls.Add(this.mnuBar);
-			this.Controls.Add(this.tabList);
-			this.Controls.Add(this.stsMain);
-			this.Controls.Add(this.pbMain);
-			this.Controls.Add(this.lblLoading);
-			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-			this.MainMenuStrip = this.mnuBar;
-			this.MinimizeBox = false;
-			this.MinimumSize = new System.Drawing.Size(300, 200);
-			this.Name = "EntryEditor";
-			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "EntryEditor";
-			this.Shown += new System.EventHandler(this.EntryEditor_Shown);
-			this.tabList.ResumeLayout(false);
-			this.tabInfo.ResumeLayout(false);
-			this.tabInfo.PerformLayout();
-			this.tabHeader.ResumeLayout(false);
-			this.tabBody.ResumeLayout(false);
-			this.mnuBar.ResumeLayout(false);
-			this.mnuBar.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.pboImage)).EndInit();
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.pbMain.Location = new System.Drawing.Point(12, 384);
+            this.pbMain.MarqueeAnimationSpeed = 10;
+            this.pbMain.Name = "pbMain";
+            this.pbMain.Size = new System.Drawing.Size(600, 23);
+            this.pbMain.Style = System.Windows.Forms.ProgressBarStyle.Marquee;
+            this.pbMain.TabIndex = 8;
+            // 
+            // pboImage
+            // 
+            this.pboImage.BackColor = System.Drawing.Color.DarkGray;
+            this.pboImage.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.pboImage.Location = new System.Drawing.Point(0, 24);
+            this.pboImage.Name = "pboImage";
+            this.pboImage.Size = new System.Drawing.Size(624, 395);
+            this.pboImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            this.pboImage.TabIndex = 9;
+            this.pboImage.TabStop = false;
+            // 
+            // EntryEditor
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(624, 441);
+            this.Controls.Add(this.pboImage);
+            this.Controls.Add(this.mnuBar);
+            this.Controls.Add(this.tabList);
+            this.Controls.Add(this.stsMain);
+            this.Controls.Add(this.pbMain);
+            this.Controls.Add(this.lblLoading);
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.MainMenuStrip = this.mnuBar;
+            this.MinimizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(300, 200);
+            this.Name = "EntryEditor";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "EntryEditor";
+            this.Shown += new System.EventHandler(this.EntryEditor_Shown);
+            this.tabList.ResumeLayout(false);
+            this.tabInfo.ResumeLayout(false);
+            this.tabInfo.PerformLayout();
+            this.tabHeader.ResumeLayout(false);
+            this.tabBody.ResumeLayout(false);
+            this.mnuBar.ResumeLayout(false);
+            this.mnuBar.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pboImage)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -331,11 +331,11 @@ namespace BundleManager
         private System.Windows.Forms.TabPage tabBody;
         private System.Windows.Forms.Label lblLoading;
         private System.Windows.Forms.MenuStrip mnuBar;
-		private System.Windows.Forms.ToolStripMenuItem editStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem editHashToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem calcLookupHashToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem binaryToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem importHeaderToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem editStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem editHashToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem calcLookupHashToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem binaryToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem importHeaderToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem exportHeaderToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripMenuItem1;
         private System.Windows.Forms.ToolStripMenuItem importBodyToolStripMenuItem;

--- a/BundleManager/EntryEditor.cs
+++ b/BundleManager/EntryEditor.cs
@@ -685,7 +685,7 @@ namespace BundleManager
             {
                 if (_entry.Console)
                     Image = GameImage.GetImagePS3(_entry.EntryBlocks[0].Data, _entry.EntryBlocks[1].Data);
-				else
+                else
                     Image = GameImage.GetImage(_entry.EntryBlocks[0].Data, _entry.EntryBlocks[1].Data);
 
                 ImageVisible = Image != null;
@@ -700,7 +700,7 @@ namespace BundleManager
 
             if (TabsVisible)
             {
-				DataHex = _entry.EntryBlocks[0].Data;//.AsString();
+                DataHex = _entry.EntryBlocks[0].Data;//.AsString();
                 ExtraDataHex = _entry.EntryBlocks[1].Data;//.AsString();
             }
 
@@ -770,11 +770,11 @@ namespace BundleManager
             ImageMenuVisible = false;
             BinaryMenuVisible = false;
 
-			ImageHeader header = GameImage.GetImageHeader(_entry.EntryBlocks[0].Data);
+            ImageHeader header = GameImage.GetImageHeader(_entry.EntryBlocks[0].Data);
 
             ImageInfo info = GameImage.SetImage(newImage, header.CompressionType);
 
-			Entry.EntryBlocks[0].Data = info.Header;
+            Entry.EntryBlocks[0].Data = info.Header;
             Entry.EntryBlocks[1].Data = info.Data;
 
             ImageVisible = false;

--- a/BundleManager/MainForm.Designer.cs
+++ b/BundleManager/MainForm.Designer.cs
@@ -28,60 +28,60 @@
         /// </summary>
         private void InitializeComponent()
         {
-			this.components = new System.ComponentModel.Container();
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
-			this.mnuMain = new System.Windows.Forms.MenuStrip();
-			this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.newToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem3 = new System.Windows.Forms.ToolStripSeparator();
-			this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
-			this.saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.saveAsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
-			this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.closeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.searchForEntryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStrip1 = new System.Windows.Forms.ToolStrip();
-			this.tsbNew = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.tsbOpen = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-			this.tsbSave = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-			this.tsbSwitchMode = new System.Windows.Forms.ToolStripButton();
-			this.lstEntries = new BundleManager.BetterListView();
-			this.colIndex = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.colName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.colID = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.colType = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.colSize = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.colPreview = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.mnuLst = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.previewToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem4 = new System.Windows.Forms.ToolStripSeparator();
-			this.viewDataToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.pluginToolsSeparatorItem = new System.Windows.Forms.ToolStripSeparator();
-			this.mnuMain.SuspendLayout();
-			this.toolStrip1.SuspendLayout();
-			this.mnuLst.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// mnuMain
-			// 
-			this.mnuMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
+            this.mnuMain = new System.Windows.Forms.MenuStrip();
+            this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.newToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem3 = new System.Windows.Forms.ToolStripSeparator();
+            this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+            this.saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveAsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
+            this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.closeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.searchForEntryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStrip1 = new System.Windows.Forms.ToolStrip();
+            this.tsbNew = new System.Windows.Forms.ToolStripButton();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.tsbOpen = new System.Windows.Forms.ToolStripButton();
+            this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+            this.tsbSave = new System.Windows.Forms.ToolStripButton();
+            this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+            this.tsbSwitchMode = new System.Windows.Forms.ToolStripButton();
+            this.lstEntries = new BundleManager.BetterListView();
+            this.colIndex = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.colName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.colID = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.colType = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.colSize = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.colPreview = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.mnuLst = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.previewToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem4 = new System.Windows.Forms.ToolStripSeparator();
+            this.viewDataToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.pluginToolsSeparatorItem = new System.Windows.Forms.ToolStripSeparator();
+            this.mnuMain.SuspendLayout();
+            this.toolStrip1.SuspendLayout();
+            this.mnuLst.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // mnuMain
+            // 
+            this.mnuMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.fileToolStripMenuItem,
             this.toolsToolStripMenuItem});
-			this.mnuMain.Location = new System.Drawing.Point(0, 0);
-			this.mnuMain.Name = "mnuMain";
-			this.mnuMain.Size = new System.Drawing.Size(784, 24);
-			this.mnuMain.TabIndex = 0;
-			this.mnuMain.Text = "menuStrip1";
-			// 
-			// fileToolStripMenuItem
-			// 
-			this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.mnuMain.Location = new System.Drawing.Point(0, 0);
+            this.mnuMain.Name = "mnuMain";
+            this.mnuMain.Size = new System.Drawing.Size(784, 24);
+            this.mnuMain.TabIndex = 0;
+            this.mnuMain.Text = "menuStrip1";
+            // 
+            // fileToolStripMenuItem
+            // 
+            this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.newToolStripMenuItem,
             this.toolStripMenuItem3,
             this.openToolStripMenuItem,
@@ -91,97 +91,97 @@
             this.toolStripMenuItem2,
             this.exitToolStripMenuItem,
             this.closeToolStripMenuItem});
-			this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-			this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
-			this.fileToolStripMenuItem.Text = "File";
-			// 
-			// newToolStripMenuItem
-			// 
-			this.newToolStripMenuItem.Image = global::BundleManager.Properties.Resources.NewDocumentHS;
-			this.newToolStripMenuItem.Name = "newToolStripMenuItem";
-			this.newToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
-			this.newToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
-			this.newToolStripMenuItem.Text = "New";
-			this.newToolStripMenuItem.Click += new System.EventHandler(this.newToolStripMenuItem_Click);
-			// 
-			// toolStripMenuItem3
-			// 
-			this.toolStripMenuItem3.Name = "toolStripMenuItem3";
-			this.toolStripMenuItem3.Size = new System.Drawing.Size(183, 6);
-			// 
-			// openToolStripMenuItem
-			// 
-			this.openToolStripMenuItem.Image = global::BundleManager.Properties.Resources.openHS;
-			this.openToolStripMenuItem.Name = "openToolStripMenuItem";
-			this.openToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-			this.openToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
-			this.openToolStripMenuItem.Text = "Open";
-			this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
-			// 
-			// toolStripMenuItem1
-			// 
-			this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-			this.toolStripMenuItem1.Size = new System.Drawing.Size(183, 6);
-			// 
-			// saveToolStripMenuItem
-			// 
-			this.saveToolStripMenuItem.Image = global::BundleManager.Properties.Resources.saveHS;
-			this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
-			this.saveToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-			this.saveToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
-			this.saveToolStripMenuItem.Text = "Save";
-			this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
-			// 
-			// saveAsToolStripMenuItem
-			// 
-			this.saveAsToolStripMenuItem.Image = global::BundleManager.Properties.Resources.SaveAllHS;
-			this.saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
-			this.saveAsToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+            this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
+            this.fileToolStripMenuItem.Text = "File";
+            // 
+            // newToolStripMenuItem
+            // 
+            this.newToolStripMenuItem.Image = global::BundleManager.Properties.Resources.NewDocumentHS;
+            this.newToolStripMenuItem.Name = "newToolStripMenuItem";
+            this.newToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
+            this.newToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
+            this.newToolStripMenuItem.Text = "New";
+            this.newToolStripMenuItem.Click += new System.EventHandler(this.newToolStripMenuItem_Click);
+            // 
+            // toolStripMenuItem3
+            // 
+            this.toolStripMenuItem3.Name = "toolStripMenuItem3";
+            this.toolStripMenuItem3.Size = new System.Drawing.Size(183, 6);
+            // 
+            // openToolStripMenuItem
+            // 
+            this.openToolStripMenuItem.Image = global::BundleManager.Properties.Resources.openHS;
+            this.openToolStripMenuItem.Name = "openToolStripMenuItem";
+            this.openToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
+            this.openToolStripMenuItem.Text = "Open";
+            this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
+            // 
+            // toolStripMenuItem1
+            // 
+            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(183, 6);
+            // 
+            // saveToolStripMenuItem
+            // 
+            this.saveToolStripMenuItem.Image = global::BundleManager.Properties.Resources.saveHS;
+            this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
+            this.saveToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
+            this.saveToolStripMenuItem.Text = "Save";
+            this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
+            // 
+            // saveAsToolStripMenuItem
+            // 
+            this.saveAsToolStripMenuItem.Image = global::BundleManager.Properties.Resources.SaveAllHS;
+            this.saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
+            this.saveAsToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.S)));
-			this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
-			this.saveAsToolStripMenuItem.Text = "Save As";
-			this.saveAsToolStripMenuItem.Click += new System.EventHandler(this.saveAsToolStripMenuItem_Click);
-			// 
-			// toolStripMenuItem2
-			// 
-			this.toolStripMenuItem2.Name = "toolStripMenuItem2";
-			this.toolStripMenuItem2.Size = new System.Drawing.Size(183, 6);
-			// 
-			// exitToolStripMenuItem
-			// 
-			this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-			this.exitToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
-			this.exitToolStripMenuItem.Text = "Exit";
-			this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
-			// 
-			// closeToolStripMenuItem
-			// 
-			this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
-			this.closeToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
-			this.closeToolStripMenuItem.Text = "Close";
-			this.closeToolStripMenuItem.Visible = false;
-			this.closeToolStripMenuItem.Click += new System.EventHandler(this.closeToolStripMenuItem_Click);
-			// 
-			// toolsToolStripMenuItem
-			// 
-			this.toolsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
+            this.saveAsToolStripMenuItem.Text = "Save As";
+            this.saveAsToolStripMenuItem.Click += new System.EventHandler(this.saveAsToolStripMenuItem_Click);
+            // 
+            // toolStripMenuItem2
+            // 
+            this.toolStripMenuItem2.Name = "toolStripMenuItem2";
+            this.toolStripMenuItem2.Size = new System.Drawing.Size(183, 6);
+            // 
+            // exitToolStripMenuItem
+            // 
+            this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
+            this.exitToolStripMenuItem.Text = "Exit";
+            this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
+            // 
+            // closeToolStripMenuItem
+            // 
+            this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
+            this.closeToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
+            this.closeToolStripMenuItem.Text = "Close";
+            this.closeToolStripMenuItem.Visible = false;
+            this.closeToolStripMenuItem.Click += new System.EventHandler(this.closeToolStripMenuItem_Click);
+            // 
+            // toolsToolStripMenuItem
+            // 
+            this.toolsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.searchForEntryToolStripMenuItem,
             this.pluginToolsSeparatorItem});
-			this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
-			this.toolsToolStripMenuItem.Size = new System.Drawing.Size(46, 20);
-			this.toolsToolStripMenuItem.Text = "Tools";
-			// 
-			// searchForEntryToolStripMenuItem
-			// 
-			this.searchForEntryToolStripMenuItem.Name = "searchForEntryToolStripMenuItem";
-			this.searchForEntryToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
-			this.searchForEntryToolStripMenuItem.Size = new System.Drawing.Size(197, 22);
-			this.searchForEntryToolStripMenuItem.Text = "Search for entry";
-			this.searchForEntryToolStripMenuItem.Click += new System.EventHandler(this.searchForEntryToolStripMenuItem_Click);
-			// 
-			// toolStrip1
-			// 
-			this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
+            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(46, 20);
+            this.toolsToolStripMenuItem.Text = "Tools";
+            // 
+            // searchForEntryToolStripMenuItem
+            // 
+            this.searchForEntryToolStripMenuItem.Name = "searchForEntryToolStripMenuItem";
+            this.searchForEntryToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
+            this.searchForEntryToolStripMenuItem.Size = new System.Drawing.Size(197, 22);
+            this.searchForEntryToolStripMenuItem.Text = "Search for entry";
+            this.searchForEntryToolStripMenuItem.Click += new System.EventHandler(this.searchForEntryToolStripMenuItem_Click);
+            // 
+            // toolStrip1
+            // 
+            this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.tsbNew,
             this.toolStripSeparator1,
             this.tsbOpen,
@@ -189,172 +189,172 @@
             this.tsbSave,
             this.toolStripSeparator3,
             this.tsbSwitchMode});
-			this.toolStrip1.Location = new System.Drawing.Point(0, 24);
-			this.toolStrip1.Name = "toolStrip1";
-			this.toolStrip1.Size = new System.Drawing.Size(784, 25);
-			this.toolStrip1.TabIndex = 1;
-			this.toolStrip1.Text = "toolStrip1";
-			// 
-			// tsbNew
-			// 
-			this.tsbNew.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.tsbNew.Image = global::BundleManager.Properties.Resources.NewDocumentHS;
-			this.tsbNew.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.tsbNew.Name = "tsbNew";
-			this.tsbNew.Size = new System.Drawing.Size(23, 22);
-			this.tsbNew.Text = "New";
-			this.tsbNew.Click += new System.EventHandler(this.tsbNew_Click);
-			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
-			// 
-			// tsbOpen
-			// 
-			this.tsbOpen.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.tsbOpen.Image = global::BundleManager.Properties.Resources.openHS;
-			this.tsbOpen.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.tsbOpen.Name = "tsbOpen";
-			this.tsbOpen.Size = new System.Drawing.Size(23, 22);
-			this.tsbOpen.Text = "Open";
-			this.tsbOpen.Click += new System.EventHandler(this.tsbOpen_Click);
-			// 
-			// toolStripSeparator2
-			// 
-			this.toolStripSeparator2.Name = "toolStripSeparator2";
-			this.toolStripSeparator2.Size = new System.Drawing.Size(6, 25);
-			// 
-			// tsbSave
-			// 
-			this.tsbSave.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.tsbSave.Image = global::BundleManager.Properties.Resources.saveHS;
-			this.tsbSave.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.tsbSave.Name = "tsbSave";
-			this.tsbSave.Size = new System.Drawing.Size(23, 22);
-			this.tsbSave.Text = "Save";
-			this.tsbSave.Click += new System.EventHandler(this.tsbSave_Click);
-			// 
-			// toolStripSeparator3
-			// 
-			this.toolStripSeparator3.Name = "toolStripSeparator3";
-			this.toolStripSeparator3.Size = new System.Drawing.Size(6, 25);
-			// 
-			// tsbSwitchMode
-			// 
-			this.tsbSwitchMode.Image = global::BundleManager.Properties.Resources.icon;
-			this.tsbSwitchMode.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.tsbSwitchMode.Name = "tsbSwitchMode";
-			this.tsbSwitchMode.Size = new System.Drawing.Size(148, 22);
-			this.tsbSwitchMode.Text = "Switch To Studio Mode";
-			this.tsbSwitchMode.Click += new System.EventHandler(this.tsbSwitchMode_Click);
-			// 
-			// lstEntries
-			// 
-			this.lstEntries.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.toolStrip1.Location = new System.Drawing.Point(0, 24);
+            this.toolStrip1.Name = "toolStrip1";
+            this.toolStrip1.Size = new System.Drawing.Size(784, 25);
+            this.toolStrip1.TabIndex = 1;
+            this.toolStrip1.Text = "toolStrip1";
+            // 
+            // tsbNew
+            // 
+            this.tsbNew.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.tsbNew.Image = global::BundleManager.Properties.Resources.NewDocumentHS;
+            this.tsbNew.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.tsbNew.Name = "tsbNew";
+            this.tsbNew.Size = new System.Drawing.Size(23, 22);
+            this.tsbNew.Text = "New";
+            this.tsbNew.Click += new System.EventHandler(this.tsbNew_Click);
+            // 
+            // toolStripSeparator1
+            // 
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
+            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
+            // 
+            // tsbOpen
+            // 
+            this.tsbOpen.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.tsbOpen.Image = global::BundleManager.Properties.Resources.openHS;
+            this.tsbOpen.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.tsbOpen.Name = "tsbOpen";
+            this.tsbOpen.Size = new System.Drawing.Size(23, 22);
+            this.tsbOpen.Text = "Open";
+            this.tsbOpen.Click += new System.EventHandler(this.tsbOpen_Click);
+            // 
+            // toolStripSeparator2
+            // 
+            this.toolStripSeparator2.Name = "toolStripSeparator2";
+            this.toolStripSeparator2.Size = new System.Drawing.Size(6, 25);
+            // 
+            // tsbSave
+            // 
+            this.tsbSave.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.tsbSave.Image = global::BundleManager.Properties.Resources.saveHS;
+            this.tsbSave.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.tsbSave.Name = "tsbSave";
+            this.tsbSave.Size = new System.Drawing.Size(23, 22);
+            this.tsbSave.Text = "Save";
+            this.tsbSave.Click += new System.EventHandler(this.tsbSave_Click);
+            // 
+            // toolStripSeparator3
+            // 
+            this.toolStripSeparator3.Name = "toolStripSeparator3";
+            this.toolStripSeparator3.Size = new System.Drawing.Size(6, 25);
+            // 
+            // tsbSwitchMode
+            // 
+            this.tsbSwitchMode.Image = global::BundleManager.Properties.Resources.icon;
+            this.tsbSwitchMode.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.tsbSwitchMode.Name = "tsbSwitchMode";
+            this.tsbSwitchMode.Size = new System.Drawing.Size(148, 22);
+            this.tsbSwitchMode.Text = "Switch To Studio Mode";
+            this.tsbSwitchMode.Click += new System.EventHandler(this.tsbSwitchMode_Click);
+            // 
+            // lstEntries
+            // 
+            this.lstEntries.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.colIndex,
             this.colName,
             this.colID,
             this.colType,
             this.colSize,
             this.colPreview});
-			this.lstEntries.ContextMenuStrip = this.mnuLst;
-			this.lstEntries.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.lstEntries.FullRowSelect = true;
-			this.lstEntries.GridLines = true;
-			this.lstEntries.HideSelection = false;
-			this.lstEntries.Location = new System.Drawing.Point(0, 49);
-			this.lstEntries.MultiSelect = false;
-			this.lstEntries.Name = "lstEntries";
-			this.lstEntries.Size = new System.Drawing.Size(784, 512);
-			this.lstEntries.TabIndex = 2;
-			this.lstEntries.UseCompatibleStateImageBehavior = false;
-			this.lstEntries.View = System.Windows.Forms.View.Details;
-			this.lstEntries.ColumnClick += new System.Windows.Forms.ColumnClickEventHandler(this.lstEntries_ColumnClick);
-			this.lstEntries.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.lstEntries_MouseDoubleClick);
-			// 
-			// colIndex
-			// 
-			this.colIndex.Text = "Index";
-			// 
-			// colName
-			// 
-			this.colName.Text = "Name";
-			this.colName.Width = 120;
-			// 
-			// colID
-			// 
-			this.colID.Text = "ID";
-			this.colID.Width = 100;
-			// 
-			// colType
-			// 
-			this.colType.Text = "Type";
-			this.colType.Width = 200;
-			// 
-			// colSize
-			// 
-			this.colSize.Text = "Size";
-			// 
-			// colPreview
-			// 
-			this.colPreview.Text = "Preview";
-			this.colPreview.Width = 300;
-			// 
-			// mnuLst
-			// 
-			this.mnuLst.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.lstEntries.ContextMenuStrip = this.mnuLst;
+            this.lstEntries.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lstEntries.FullRowSelect = true;
+            this.lstEntries.GridLines = true;
+            this.lstEntries.HideSelection = false;
+            this.lstEntries.Location = new System.Drawing.Point(0, 49);
+            this.lstEntries.MultiSelect = false;
+            this.lstEntries.Name = "lstEntries";
+            this.lstEntries.Size = new System.Drawing.Size(784, 512);
+            this.lstEntries.TabIndex = 2;
+            this.lstEntries.UseCompatibleStateImageBehavior = false;
+            this.lstEntries.View = System.Windows.Forms.View.Details;
+            this.lstEntries.ColumnClick += new System.Windows.Forms.ColumnClickEventHandler(this.lstEntries_ColumnClick);
+            this.lstEntries.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.lstEntries_MouseDoubleClick);
+            // 
+            // colIndex
+            // 
+            this.colIndex.Text = "Index";
+            // 
+            // colName
+            // 
+            this.colName.Text = "Name";
+            this.colName.Width = 120;
+            // 
+            // colID
+            // 
+            this.colID.Text = "ID";
+            this.colID.Width = 100;
+            // 
+            // colType
+            // 
+            this.colType.Text = "Type";
+            this.colType.Width = 200;
+            // 
+            // colSize
+            // 
+            this.colSize.Text = "Size";
+            // 
+            // colPreview
+            // 
+            this.colPreview.Text = "Preview";
+            this.colPreview.Width = 300;
+            // 
+            // mnuLst
+            // 
+            this.mnuLst.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.previewToolStripMenuItem,
             this.toolStripMenuItem4,
             this.viewDataToolStripMenuItem});
-			this.mnuLst.Name = "mnuLst";
-			this.mnuLst.Size = new System.Drawing.Size(141, 54);
-			// 
-			// previewToolStripMenuItem
-			// 
-			this.previewToolStripMenuItem.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.previewToolStripMenuItem.Name = "previewToolStripMenuItem";
-			this.previewToolStripMenuItem.Size = new System.Drawing.Size(140, 22);
-			this.previewToolStripMenuItem.Text = "Preview";
-			this.previewToolStripMenuItem.Click += new System.EventHandler(this.previewToolStripMenuItem_Click);
-			// 
-			// toolStripMenuItem4
-			// 
-			this.toolStripMenuItem4.Name = "toolStripMenuItem4";
-			this.toolStripMenuItem4.Size = new System.Drawing.Size(137, 6);
-			// 
-			// viewDataToolStripMenuItem
-			// 
-			this.viewDataToolStripMenuItem.Name = "viewDataToolStripMenuItem";
-			this.viewDataToolStripMenuItem.Size = new System.Drawing.Size(140, 22);
-			this.viewDataToolStripMenuItem.Text = "View Header";
-			this.viewDataToolStripMenuItem.Click += new System.EventHandler(this.viewDataToolStripMenuItem_Click);
-			// 
-			// pluginToolsSeparatorItem
-			// 
-			this.pluginToolsSeparatorItem.Name = "pluginToolsSeparatorItem";
-			this.pluginToolsSeparatorItem.Size = new System.Drawing.Size(194, 6);
-			// 
-			// MainForm
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(784, 561);
-			this.Controls.Add(this.lstEntries);
-			this.Controls.Add(this.toolStrip1);
-			this.Controls.Add(this.mnuMain);
-			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-			this.MainMenuStrip = this.mnuMain;
-			this.Name = "MainForm";
-			this.Text = "Burnout Bundle Manager";
-			this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainForm_FormClosing);
-			this.mnuMain.ResumeLayout(false);
-			this.mnuMain.PerformLayout();
-			this.toolStrip1.ResumeLayout(false);
-			this.toolStrip1.PerformLayout();
-			this.mnuLst.ResumeLayout(false);
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.mnuLst.Name = "mnuLst";
+            this.mnuLst.Size = new System.Drawing.Size(141, 54);
+            // 
+            // previewToolStripMenuItem
+            // 
+            this.previewToolStripMenuItem.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.previewToolStripMenuItem.Name = "previewToolStripMenuItem";
+            this.previewToolStripMenuItem.Size = new System.Drawing.Size(140, 22);
+            this.previewToolStripMenuItem.Text = "Preview";
+            this.previewToolStripMenuItem.Click += new System.EventHandler(this.previewToolStripMenuItem_Click);
+            // 
+            // toolStripMenuItem4
+            // 
+            this.toolStripMenuItem4.Name = "toolStripMenuItem4";
+            this.toolStripMenuItem4.Size = new System.Drawing.Size(137, 6);
+            // 
+            // viewDataToolStripMenuItem
+            // 
+            this.viewDataToolStripMenuItem.Name = "viewDataToolStripMenuItem";
+            this.viewDataToolStripMenuItem.Size = new System.Drawing.Size(140, 22);
+            this.viewDataToolStripMenuItem.Text = "View Header";
+            this.viewDataToolStripMenuItem.Click += new System.EventHandler(this.viewDataToolStripMenuItem_Click);
+            // 
+            // pluginToolsSeparatorItem
+            // 
+            this.pluginToolsSeparatorItem.Name = "pluginToolsSeparatorItem";
+            this.pluginToolsSeparatorItem.Size = new System.Drawing.Size(194, 6);
+            // 
+            // MainForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(784, 561);
+            this.Controls.Add(this.lstEntries);
+            this.Controls.Add(this.toolStrip1);
+            this.Controls.Add(this.mnuMain);
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.MainMenuStrip = this.mnuMain;
+            this.Name = "MainForm";
+            this.Text = "Burnout Bundle Manager";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainForm_FormClosing);
+            this.mnuMain.ResumeLayout(false);
+            this.mnuMain.PerformLayout();
+            this.toolStrip1.ResumeLayout(false);
+            this.toolStrip1.PerformLayout();
+            this.mnuLst.ResumeLayout(false);
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -392,7 +392,7 @@
         private System.Windows.Forms.ToolStripMenuItem toolsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem searchForEntryToolStripMenuItem;
         private System.Windows.Forms.ColumnHeader colName;
-		private System.Windows.Forms.ToolStripSeparator pluginToolsSeparatorItem;
-	}
+        private System.Windows.Forms.ToolStripSeparator pluginToolsSeparatorItem;
+    }
 }
 

--- a/BundleManager/MainForm.cs
+++ b/BundleManager/MainForm.cs
@@ -20,9 +20,9 @@ namespace BundleManager
 {
     public partial class MainForm : Form
     {
-		#region Variables and Properties
+        #region Variables and Properties
 
-		private bool _subForm;
+        private bool _subForm;
         public bool SubForm
         {
             get { return _subForm; }
@@ -137,13 +137,13 @@ namespace BundleManager
 
         public bool _console => CurrentArchive.Console;
 
-		public bool ForceOnlySpecificEntry = false;
+        public bool ForceOnlySpecificEntry = false;
 
-		private Thread _openSaveThread;
+        private Thread _openSaveThread;
 
-		#endregion
+        #endregion
 
-		public MainForm()
+        public MainForm()
         {
             InitializeComponent();
 
@@ -155,7 +155,7 @@ namespace BundleManager
         {
             lstEntries.Items.Clear();
 
-			UpdatePluginMenu();
+            UpdatePluginMenu();
 
             if (CurrentArchive == null)
             {
@@ -193,50 +193,50 @@ namespace BundleManager
             lstEntries.EndUpdate();
         }
 
-		private void UpdatePluginMenu()
-		{
-			int index = toolsToolStripMenuItem.DropDownItems.IndexOf(pluginToolsSeparatorItem) + 1;
+        private void UpdatePluginMenu()
+        {
+            int index = toolsToolStripMenuItem.DropDownItems.IndexOf(pluginToolsSeparatorItem) + 1;
 
-			while(true)
-			{
-				if (index >= toolsToolStripMenuItem.DropDownItems.Count)
-					break;
+            while(true)
+            {
+                if (index >= toolsToolStripMenuItem.DropDownItems.Count)
+                    break;
 
-				if (toolsToolStripMenuItem.DropDownItems[index] is ToolStripSeparator)
-					break;
+                if (toolsToolStripMenuItem.DropDownItems[index] is ToolStripSeparator)
+                    break;
 
-				toolsToolStripMenuItem.DropDownItems.RemoveAt(index);
-			}
+                toolsToolStripMenuItem.DropDownItems.RemoveAt(index);
+            }
 
-			PluginCommand[] commands = PluginCommandRegistry.Commands;
+            PluginCommand[] commands = PluginCommandRegistry.Commands;
 
-			if (commands.Length == 0)
-			{
-				ToolStripItem item = new ToolStripMenuItem("No Plugin Commands");
-				item.Enabled = false;
+            if (commands.Length == 0)
+            {
+                ToolStripItem item = new ToolStripMenuItem("No Plugin Commands");
+                item.Enabled = false;
 
-				toolsToolStripMenuItem.DropDownItems.Insert(index, item);
-			}
-			else
-			{
-				for (int i = 0; i < commands.Length; i++)
-				{
-					PluginCommand command = commands[i];
+                toolsToolStripMenuItem.DropDownItems.Insert(index, item);
+            }
+            else
+            {
+                for (int i = 0; i < commands.Length; i++)
+                {
+                    PluginCommand command = commands[i];
 
-					ToolStripItem item = new ToolStripMenuItem(command.Text);
-					if (CurrentArchive == null)
-						item.Enabled = false;
-					else if (command.CheckConditions == null)
-						item.Enabled = true;
-					else
-						item.Enabled = command.CheckConditions(CurrentArchive);
+                    ToolStripItem item = new ToolStripMenuItem(command.Text);
+                    if (CurrentArchive == null)
+                        item.Enabled = false;
+                    else if (command.CheckConditions == null)
+                        item.Enabled = true;
+                    else
+                        item.Enabled = command.CheckConditions(CurrentArchive);
 
-					item.Click += (sender, args) => command.Use(this, CurrentArchive);
+                    item.Click += (sender, args) => command.Use(this, CurrentArchive);
 
-					toolsToolStripMenuItem.DropDownItems.Insert(index + i, item);
-				}
-			}
-		}
+                    toolsToolStripMenuItem.DropDownItems.Insert(index + i, item);
+                }
+            }
+        }
 
         private void DoNew()
         {
@@ -377,7 +377,7 @@ namespace BundleManager
 
         public void DoSaveBundle(LoadingDialog loader, string path)
         {
-			CurrentArchive.Write(path);
+            CurrentArchive.Write(path);
 
             loader.IsDone = true;
         }
@@ -410,86 +410,86 @@ namespace BundleManager
             if (!int.TryParse(lstEntries.SelectedItems[0].Text, out index))
                 return;
 
-			EditEntry(index, forceHex);
+            EditEntry(index, forceHex);
         }
 
-		public void EditEntry(int index, bool forceHex = false)
-		{
-			BundleEntry entry = GetEntry(index);
+        public void EditEntry(int index, bool forceHex = false)
+        {
+            BundleEntry entry = GetEntry(index);
 
-			if (EntryTypeRegistry.IsRegistered(entry.Type) && !forceHex)
-			{
-				IEntryData data = EntryTypeRegistry.GetHandler(entry.Type);
+            if (EntryTypeRegistry.IsRegistered(entry.Type) && !forceHex)
+            {
+                IEntryData data = EntryTypeRegistry.GetHandler(entry.Type);
 
-				TextureCache.ResetCache();
-				LoadingDialog loader = new LoadingDialog();
-				loader.Status = "Loading: " + entry.ID.ToString("X8");
+                TextureCache.ResetCache();
+                LoadingDialog loader = new LoadingDialog();
+                loader.Status = "Loading: " + entry.ID.ToString("X8");
 
-				Thread loadInstanceThread = null;
-				bool failure = false;
+                Thread loadInstanceThread = null;
+                bool failure = false;
 
-				loader.Done += (cancelled, value) =>
-				{
-					if (cancelled)
-						loadInstanceThread?.Abort();
-					else
-					{
-						if (failure)
-						{
-							MessageBox.Show(this, "Failed to load Entry", "Error", MessageBoxButtons.OK,
-								MessageBoxIcon.Error);
-						}
-						else
-						{
-							loader.Hide();
+                loader.Done += (cancelled, value) =>
+                {
+                    if (cancelled)
+                        loadInstanceThread?.Abort();
+                    else
+                    {
+                        if (failure)
+                        {
+                            MessageBox.Show(this, "Failed to load Entry", "Error", MessageBoxButtons.OK,
+                                MessageBoxIcon.Error);
+                        }
+                        else
+                        {
+                            loader.Hide();
 
-							IEntryEditor editor = data.GetEditor(entry);
-							if (editor != null)
-								editor.ShowDialog(this);
-							else
-								DebugUtil.ShowDebug(this, data);
-							if (ForceOnlySpecificEntry)
-								Environment.Exit(0);
-						}
-					}
-					TextureCache.ResetCache();
-				};
+                            IEntryEditor editor = data.GetEditor(entry);
+                            if (editor != null)
+                                editor.ShowDialog(this);
+                            else
+                                DebugUtil.ShowDebug(this, data);
+                            if (ForceOnlySpecificEntry)
+                                Environment.Exit(0);
+                        }
+                    }
+                    TextureCache.ResetCache();
+                };
 
-				loadInstanceThread = new Thread(() =>
-				{
-					try
-					{
-						try
-						{
-							failure = !data.Read(entry, loader);
-						}
-						catch (ReadFailedError ex)
-						{
-							MessageBox.Show(this, ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-							failure = true;
+                loadInstanceThread = new Thread(() =>
+                {
+                    try
+                    {
+                        try
+                        {
+                            failure = !data.Read(entry, loader);
+                        }
+                        catch (ReadFailedError ex)
+                        {
+                            MessageBox.Show(this, ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                            failure = true;
 
-							throw;
-						}
-					}
-					catch (Exception)
-					{
-						MessageBox.Show("Failed to load Entry", "Error", MessageBoxButtons.OK,
-							MessageBoxIcon.Error);
-						failure = true;
-					}
-					loader.IsDone = true;
-				});
-				loadInstanceThread.Start();
-				loader.ShowDialog(this);
-			}
-			else
-			{
-				EntryEditor editor = new EntryEditor();
-				editor.ForceHex = forceHex;
-				Task.Run(() => openEditor(editor, index));
-				editor.ShowDialog(this);
-			}
-		}
+                            throw;
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        MessageBox.Show("Failed to load Entry", "Error", MessageBoxButtons.OK,
+                            MessageBoxIcon.Error);
+                        failure = true;
+                    }
+                    loader.IsDone = true;
+                });
+                loadInstanceThread.Start();
+                loader.ShowDialog(this);
+            }
+            else
+            {
+                EntryEditor editor = new EntryEditor();
+                editor.ForceHex = forceHex;
+                Task.Run(() => openEditor(editor, index));
+                editor.ShowDialog(this);
+            }
+        }
 
 
         public void openEditor(EntryEditor editor, int index)
@@ -497,9 +497,9 @@ namespace BundleManager
             editor.Entry = GetEntry(index);
         }
 
-		#region Event Handlers
+        #region Event Handlers
 
-		private void newToolStripMenuItem_Click(object sender, EventArgs e)
+        private void newToolStripMenuItem_Click(object sender, EventArgs e)
         {
             DoNew();
         }
@@ -567,7 +567,7 @@ namespace BundleManager
 
         private void tsbSwitchMode_Click(object sender, EventArgs e)
         {
-			SwitchMode();
+            SwitchMode();
         }
 
         private void closeToolStripMenuItem_Click(object sender, EventArgs e)
@@ -577,151 +577,151 @@ namespace BundleManager
 
         private void lstEntries_ColumnClick(object sender, ColumnClickEventArgs e)
         {
-			SortColumn(e.Column);
-		}
+            SortColumn(e.Column);
+        }
 
         private void searchForEntryToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Search();
         }
 
-		#endregion
+        #endregion
 
-		#region Utility
+        #region Utility
 
-		private bool CheckSave()
-		{
-			if (CurrentArchive == null)
-			{
-				return true;
-			}
-			else if (CurrentArchive.Dirty)
-			{
-				DialogResult result = MessageBox.Show(this, "There are unsaved changes!\nWould you like to save?",
-					"Save", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Warning);
-				if (result == DialogResult.Yes)
-				{
-					return Save();
-				}
-				else if (result == DialogResult.No)
-				{
-					CurrentArchive = null;
-					CurrentFileName = null;
-					UpdateDisplay();
-					return true;
-				}
-				else
-				{
-					return false;
-				}
+        private bool CheckSave()
+        {
+            if (CurrentArchive == null)
+            {
+                return true;
+            }
+            else if (CurrentArchive.Dirty)
+            {
+                DialogResult result = MessageBox.Show(this, "There are unsaved changes!\nWould you like to save?",
+                    "Save", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Warning);
+                if (result == DialogResult.Yes)
+                {
+                    return Save();
+                }
+                else if (result == DialogResult.No)
+                {
+                    CurrentArchive = null;
+                    CurrentFileName = null;
+                    UpdateDisplay();
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
 
-			}
-			else
-			{
-				return true;
-			}
-		}
+            }
+            else
+            {
+                return true;
+            }
+        }
 
-		private void Search()
-		{
-			if (CurrentArchive == null)
-				return;
+        private void Search()
+        {
+            if (CurrentArchive == null)
+                return;
 
-			SearchDialog search = new SearchDialog();
-			search.Search += id =>
-			{
-				BundleEntry entry = CurrentArchive.GetEntryByID(id);
-				if (entry == null)
-				{
-					MessageBox.Show(this, "Entry not found!", "Information", MessageBoxButtons.OK,
-						MessageBoxIcon.Information);
-					return;
-				}
+            SearchDialog search = new SearchDialog();
+            search.Search += id =>
+            {
+                BundleEntry entry = CurrentArchive.GetEntryByID(id);
+                if (entry == null)
+                {
+                    MessageBox.Show(this, "Entry not found!", "Information", MessageBoxButtons.OK,
+                        MessageBoxIcon.Information);
+                    return;
+                }
 
-				string indexText = CurrentArchive.Entries.IndexOf(entry).ToString("D3");
-				int listIndex = -1;
-				for (int i = 0; i < lstEntries.Items.Count; i++)
-				{
-					ListViewItem item = lstEntries.Items[i];
-					if (item.Text == indexText)
-					{
-						listIndex = i;
-						break;
-					}
-				}
+                string indexText = CurrentArchive.Entries.IndexOf(entry).ToString("D3");
+                int listIndex = -1;
+                for (int i = 0; i < lstEntries.Items.Count; i++)
+                {
+                    ListViewItem item = lstEntries.Items[i];
+                    if (item.Text == indexText)
+                    {
+                        listIndex = i;
+                        break;
+                    }
+                }
 
-				lstEntries.SelectedIndices.Clear();
-				lstEntries.SelectedIndices.Add(listIndex);
-				lstEntries.EnsureVisible(listIndex);
-			};
-			search.ShowDialog(this);
-		}
+                lstEntries.SelectedIndices.Clear();
+                lstEntries.SelectedIndices.Add(listIndex);
+                lstEntries.EnsureVisible(listIndex);
+            };
+            search.ShowDialog(this);
+        }
 
-		private void SwitchMode()
-		{
-			if (!CheckSave())
-				return;
+        private void SwitchMode()
+        {
+            if (!CheckSave())
+                return;
 
-			CurrentArchive = null;
-			CurrentFileName = null;
+            CurrentArchive = null;
+            CurrentFileName = null;
 
-			Hide();
-			Program.folderModeForm.Show();
-		}
+            Hide();
+            Program.folderModeForm.Show();
+        }
 
-		private void SortColumn(int column)
-		{
-			EntrySorter sorter;
+        private void SortColumn(int column)
+        {
+            EntrySorter sorter;
 
-			if (lstEntries.ListViewItemSorter is EntrySorter)
-			{
-				// every other time
-				sorter = lstEntries.ListViewItemSorter as EntrySorter;
-				sorter.Column = column;
-			}
-			else
-			{
-				// first time
-				sorter = new EntrySorter(column);
-				lstEntries.ListViewItemSorter = sorter;
-			}
-			// if you're clicking the same column already being sorted
-			//if (sorter.Column == column)
-			//{
-			// change the direction state from true to false or vice-versa
-			sorter.Swap();
-			// bop-it
-			lstEntries.Sort();
-			//}
-		}
+            if (lstEntries.ListViewItemSorter is EntrySorter)
+            {
+                // every other time
+                sorter = lstEntries.ListViewItemSorter as EntrySorter;
+                sorter.Column = column;
+            }
+            else
+            {
+                // first time
+                sorter = new EntrySorter(column);
+                lstEntries.ListViewItemSorter = sorter;
+            }
+            // if you're clicking the same column already being sorted
+            //if (sorter.Column == column)
+            //{
+            // change the direction state from true to false or vice-versa
+            sorter.Swap();
+            // bop-it
+            lstEntries.Sort();
+            //}
+        }
 
-		private class EntrySorter : IComparer
-		{
-			public int Column;
-			public bool Direction;
+        private class EntrySorter : IComparer
+        {
+            public int Column;
+            public bool Direction;
 
-			public EntrySorter(int column)
-			{
-				this.Column = column;
-				this.Direction = false;
-			}
+            public EntrySorter(int column)
+            {
+                this.Column = column;
+                this.Direction = false;
+            }
 
-			public int Compare(object x, object y)
-			{
-				ListViewItem itemX = (ListViewItem)x;
-				ListViewItem itemY = (ListViewItem)y;
+            public int Compare(object x, object y)
+            {
+                ListViewItem itemX = (ListViewItem)x;
+                ListViewItem itemY = (ListViewItem)y;
 
-				if (Column > itemX?.SubItems.Count || Column > itemY?.SubItems.Count)
-				{
-					if (this.Direction)
-						return -1;
-					return 1;
-				}
+                if (Column > itemX?.SubItems.Count || Column > itemY?.SubItems.Count)
+                {
+                    if (this.Direction)
+                        return -1;
+                    return 1;
+                }
 
-				string iX = itemX?.SubItems[Column].Text;
-				string iY = itemY?.SubItems[Column].Text;
+                string iX = itemX?.SubItems[Column].Text;
+                string iY = itemY?.SubItems[Column].Text;
 
-				/*
+                /*
                 if (int.TryParse(iX, NumberStyles.HexNumber, CultureInfo.CurrentCulture, out var iXint))
                 {
                     if (int.TryParse(iY, NumberStyles.HexNumber, CultureInfo.CurrentCulture, out var iYint))
@@ -732,21 +732,21 @@ namespace BundleManager
                         return val2;
                     }
                 }
-				*/
+                */
 
-				int val = Math.Sign(string.Compare(iX, iY, StringComparison.CurrentCultureIgnoreCase));
-				if (this.Direction)
-					return val * -1;
-				return val;
+                int val = Math.Sign(string.Compare(iX, iY, StringComparison.CurrentCultureIgnoreCase));
+                if (this.Direction)
+                    return val * -1;
+                return val;
 
-			}
+            }
 
-			public void Swap()
-			{
-				this.Direction = !this.Direction;
-			}
-		}
+            public void Swap()
+            {
+                this.Direction = !this.Direction;
+            }
+        }
 
-		#endregion
-	}
+        #endregion
+    }
 }

--- a/BundleManager/Program.cs
+++ b/BundleManager/Program.cs
@@ -22,7 +22,7 @@ namespace BundleManager
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
-			PluginLoader.LoadPlugins();
+            PluginLoader.LoadPlugins();
 
             fileModeForm = new MainForm();
             folderModeForm = new FileView();
@@ -56,15 +56,15 @@ namespace BundleManager
                     else
                     {
                         fileModeForm.Open(path);
-						if (args.Length >= 2)
-						{
-							string indexString = args[1];
-							if (int.TryParse(indexString, out int index))
-							{
-								fileModeForm.ForceOnlySpecificEntry = true;
-								fileModeForm.EditEntry(index);
-							}
-						}
+                        if (args.Length >= 2)
+                        {
+                            string indexString = args[1];
+                            if (int.TryParse(indexString, out int index))
+                            {
+                                fileModeForm.ForceOnlySpecificEntry = true;
+                                fileModeForm.EditEntry(index);
+                            }
+                        }
                         Application.Run(fileModeForm);
                     }
                 }

--- a/BundleUtilities/BitScan.cs
+++ b/BundleUtilities/BitScan.cs
@@ -7,39 +7,39 @@ using System.Threading.Tasks;
 
 namespace BundleUtilities
 {
-	public static class BitScan
-	{
-		private const ulong DeBruijnSequence = 0x37E84A99DAE458F;
+    public static class BitScan
+    {
+        private const ulong DeBruijnSequence = 0x37E84A99DAE458F;
 
-		private static readonly int[] MultiplyDeBruijnBitPosition =
-		{
-		0, 1, 17, 2, 18, 50, 3, 57,
-		47, 19, 22, 51, 29, 4, 33, 58,
-		15, 48, 20, 27, 25, 23, 52, 41,
-		54, 30, 38, 5, 43, 34, 59, 8,
-		63, 16, 49, 56, 46, 21, 28, 32,
-		14, 26, 24, 40, 53, 37, 42, 7,
-		62, 55, 45, 31, 13, 39, 36, 6,
-		61, 44, 12, 35, 60, 11, 10, 9,
-	};
+        private static readonly int[] MultiplyDeBruijnBitPosition =
+        {
+        0, 1, 17, 2, 18, 50, 3, 57,
+        47, 19, 22, 51, 29, 4, 33, 58,
+        15, 48, 20, 27, 25, 23, 52, 41,
+        54, 30, 38, 5, 43, 34, 59, 8,
+        63, 16, 49, 56, 46, 21, 28, 32,
+        14, 26, 24, 40, 53, 37, 42, 7,
+        62, 55, 45, 31, 13, 39, 36, 6,
+        61, 44, 12, 35, 60, 11, 10, 9,
+    };
 
-		/// <summary>
-		/// Search the mask data from least significant bit (LSB) to the most significant bit (MSB) for a set bit (1)
-		/// using De Bruijn sequence approach. Warning: Will return zero for b = 0.
-		/// </summary>
-		/// <param name="b">Target number.</param>
-		/// <returns>Zero-based position of LSB (from right to left).</returns>
-		public static int BitScanForward(ulong b)
-		{
-			Debug.Assert(b > 0, "Target number should not be zero");
-			return MultiplyDeBruijnBitPosition[((ulong)((long)b & -(long)b) * DeBruijnSequence) >> 58];
-		}
+        /// <summary>
+        /// Search the mask data from least significant bit (LSB) to the most significant bit (MSB) for a set bit (1)
+        /// using De Bruijn sequence approach. Warning: Will return zero for b = 0.
+        /// </summary>
+        /// <param name="b">Target number.</param>
+        /// <returns>Zero-based position of LSB (from right to left).</returns>
+        public static int BitScanForward(ulong b)
+        {
+            Debug.Assert(b > 0, "Target number should not be zero");
+            return MultiplyDeBruijnBitPosition[((ulong)((long)b & -(long)b) * DeBruijnSequence) >> 58];
+        }
 
-		public static int BitScanReverse(uint mask)
-		{
-			int i;
-			for (i = 31; (mask >> i) == 0 && i >= 0; i--) ;
-			return i;
-		}
-	}
+        public static int BitScanReverse(uint mask)
+        {
+            int i;
+            for (i = 31; (mask >> i) == 0 && i >= 0; i--) ;
+            return i;
+        }
+    }
 }

--- a/BundleUtilities/Config.cs
+++ b/BundleUtilities/Config.cs
@@ -6,8 +6,8 @@ using System.Threading.Tasks;
 
 namespace BundleUtilities
 {
-	public static class Config
-	{
-		public static bool LoadMaterials;
-	}
+    public static class Config
+    {
+        public static bool LoadMaterials;
+    }
 }

--- a/BundleUtilities/TextureCache.cs
+++ b/BundleUtilities/TextureCache.cs
@@ -7,36 +7,36 @@ using System.Threading.Tasks;
 
 namespace BundleUtilities
 {
-	public static class TextureCache
-	{
-		private static readonly Dictionary<ulong, Image> _cachedTextures = new Dictionary<ulong, Image>();
+    public static class TextureCache
+    {
+        private static readonly Dictionary<ulong, Image> _cachedTextures = new Dictionary<ulong, Image>();
 
-		public static void ResetCache()
-		{
-			foreach (ulong key in _cachedTextures.Keys)
-			{
-				Image img = _cachedTextures[key];
-				img.Dispose();
-			}
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-			GC.Collect();
-			_cachedTextures.Clear();
-		}
+        public static void ResetCache()
+        {
+            foreach (ulong key in _cachedTextures.Keys)
+            {
+                Image img = _cachedTextures[key];
+                img.Dispose();
+            }
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            _cachedTextures.Clear();
+        }
 
-		public static void AddToCache(ulong id, Image image)
-		{
-			_cachedTextures[id] = image;
-		}
+        public static void AddToCache(ulong id, Image image)
+        {
+            _cachedTextures[id] = image;
+        }
 
-		public static bool Contains(ulong key)
-		{
-			return _cachedTextures.ContainsKey(key);
-		}
+        public static bool Contains(ulong key)
+        {
+            return _cachedTextures.ContainsKey(key);
+        }
 
-		public static Image GetTexture(ulong key)
-		{
-			return _cachedTextures[key];
-		}
-	}
+        public static Image GetTexture(ulong key)
+        {
+            return _cachedTextures[key];
+        }
+    }
 }

--- a/BundleUtilities/Utilities.cs
+++ b/BundleUtilities/Utilities.cs
@@ -49,20 +49,20 @@ namespace BundleUtilities
         {
             StringBuilder sb = new StringBuilder();
 
-			try
-			{
-				while (true)
-				{
-					char c = (char)self.ReadByte();
-					if (c == '\0')
-						break;
-					sb.Append(c);
-				}
-			}
-			catch (EndOfStreamException)
-			{
-				// Ignore
-			}
+            try
+            {
+                while (true)
+                {
+                    char c = (char)self.ReadByte();
+                    if (c == '\0')
+                        break;
+                    sb.Append(c);
+                }
+            }
+            catch (EndOfStreamException)
+            {
+                // Ignore
+            }
 
             return sb.ToString();
         }

--- a/BurnoutImage/DirectBitmap.cs
+++ b/BurnoutImage/DirectBitmap.cs
@@ -5,63 +5,63 @@ using System.Runtime.InteropServices;
 
 namespace BurnoutImage
 {
-	public class DirectBitmap : IDisposable
-	{
-		public Bitmap Bitmap { get; private set; }
-		//public byte[] Bits { get; private set; }
-		public int[] Bits { get; private set; }
-		public bool Disposed { get; private set; }
-		public int Height { get; private set; }
-		public int Width { get; private set; }
+    public class DirectBitmap : IDisposable
+    {
+        public Bitmap Bitmap { get; private set; }
+        //public byte[] Bits { get; private set; }
+        public int[] Bits { get; private set; }
+        public bool Disposed { get; private set; }
+        public int Height { get; private set; }
+        public int Width { get; private set; }
 
-		protected GCHandle BitsHandle { get; private set; }
+        protected GCHandle BitsHandle { get; private set; }
 
-		public DirectBitmap(int width, int height)
-		{
-			Width = width;
-			Height = height;
-			//Bits = new byte[width * height * 4];
-			Bits = new int[width * height];
-			BitsHandle = GCHandle.Alloc(Bits, GCHandleType.Pinned);
-			Bitmap = new Bitmap(width, height, width * 4, PixelFormat.Format32bppPArgb, BitsHandle.AddrOfPinnedObject());
-		}
+        public DirectBitmap(int width, int height)
+        {
+            Width = width;
+            Height = height;
+            //Bits = new byte[width * height * 4];
+            Bits = new int[width * height];
+            BitsHandle = GCHandle.Alloc(Bits, GCHandleType.Pinned);
+            Bitmap = new Bitmap(width, height, width * 4, PixelFormat.Format32bppPArgb, BitsHandle.AddrOfPinnedObject());
+        }
 
-		public void SetPixel(int x, int y, Color colour)
-		{
-			int index = x + (y * Width);
+        public void SetPixel(int x, int y, Color colour)
+        {
+            int index = x + (y * Width);
 
-			/*Bits[index + 0] = colour.A;
-			Bits[index + 1] = colour.R;
-			Bits[index + 2] = colour.G;
-			Bits[index + 3] = colour.B;*/
+            /*Bits[index + 0] = colour.A;
+            Bits[index + 1] = colour.R;
+            Bits[index + 2] = colour.G;
+            Bits[index + 3] = colour.B;*/
 
-			int col = colour.ToArgb();
+            int col = colour.ToArgb();
 
-			Bits[index] = col;
-		}
+            Bits[index] = col;
+        }
 
-		public Color GetPixel(int x, int y)
-		{
-			int index = x + (y * Width);
+        public Color GetPixel(int x, int y)
+        {
+            int index = x + (y * Width);
 
-			/*byte alpha = Bits[index + 0];
-			byte red = Bits[index + 1];
-			byte green = Bits[index + 2];
-			byte blue = Bits[index + 3];
-			Color result = Color.FromArgb(alpha, red, green, blue);*/
+            /*byte alpha = Bits[index + 0];
+            byte red = Bits[index + 1];
+            byte green = Bits[index + 2];
+            byte blue = Bits[index + 3];
+            Color result = Color.FromArgb(alpha, red, green, blue);*/
 
-			int col = Bits[index];
-			Color result = Color.FromArgb(col);
+            int col = Bits[index];
+            Color result = Color.FromArgb(col);
 
-			return result;
-		}
+            return result;
+        }
 
-		public void Dispose()
-		{
-			if (Disposed) return;
-			Disposed = true;
-			Bitmap.Dispose();
-			BitsHandle.Free();
-		}
-	}
+        public void Dispose()
+        {
+            if (Disposed) return;
+            Disposed = true;
+            Bitmap.Dispose();
+            BitsHandle.Free();
+        }
+    }
 }

--- a/BurnoutImage/Extensions.cs
+++ b/BurnoutImage/Extensions.cs
@@ -6,22 +6,22 @@ using System.Threading.Tasks;
 
 namespace BurnoutImage
 {
-	internal static class Extensions
-	{
-		internal static bool Matches(this byte[] self, byte[] other)
-		{
-			if (self == null || other == null)
-				return false;
-			if (self.Length != other.Length)
-				return false;
+    internal static class Extensions
+    {
+        internal static bool Matches(this byte[] self, byte[] other)
+        {
+            if (self == null || other == null)
+                return false;
+            if (self.Length != other.Length)
+                return false;
 
-			for (int i = 0; i < self.Length; i++)
-			{
-				if (self[i] != other[i])
-					return false;
-			}
+            for (int i = 0; i < self.Length; i++)
+            {
+                if (self[i] != other[i])
+                    return false;
+            }
 
-			return true;
-		}
-	}
+            return true;
+        }
+    }
 }

--- a/BurnoutImage/GameImage.cs
+++ b/BurnoutImage/GameImage.cs
@@ -11,279 +11,279 @@ using BundleUtilities;
 
 namespace BurnoutImage
 {
-	public struct ImageInfo
-	{
-		public readonly byte[] Header;
-		public readonly byte[] Data;
+    public struct ImageInfo
+    {
+        public readonly byte[] Header;
+        public readonly byte[] Data;
 
-		public ImageInfo(byte[] header, byte[] data)
-		{
-			this.Header = header;
-			this.Data = data;
-		}
-	}
+        public ImageInfo(byte[] header, byte[] data)
+        {
+            this.Header = header;
+            this.Data = data;
+        }
+    }
 
-	public class ImageHeader
-	{
-		public readonly CompressionType CompressionType;
-		public readonly int Width, Height;
+    public class ImageHeader
+    {
+        public readonly CompressionType CompressionType;
+        public readonly int Width, Height;
 
-		public ImageHeader(CompressionType compression, int width, int height)
-		{
-			CompressionType = compression;
-			Width = width;
-			Height = height;
-		}
-	}
+        public ImageHeader(CompressionType compression, int width, int height)
+        {
+            CompressionType = compression;
+            Width = width;
+            Height = height;
+        }
+    }
 
-	public static class GameImage
+    public static class GameImage
     {
         public static ImageInfo SetImage(Image newImage, CompressionType compression)
         {
             int width = newImage.Width;
             int height = newImage.Height;
-			byte[] header = null;
-			byte[] data = null;
+            byte[] header = null;
+            byte[] data = null;
 
-			if (compression == CompressionType.BGRA)
-			{
-				Bitmap image = new Bitmap(newImage);
-				MemoryStream mspixels = new MemoryStream();
+            if (compression == CompressionType.BGRA)
+            {
+                Bitmap image = new Bitmap(newImage);
+                MemoryStream mspixels = new MemoryStream();
 
-				for (int i = 0; i < height; i++)
-				{
-					for (int j = 0; j < width; j++)
-					{
-						Color pixel = image.GetPixel(j, i);
-						mspixels.WriteByte(pixel.B);
-						mspixels.WriteByte(pixel.G);
-						mspixels.WriteByte(pixel.R);
-						mspixels.WriteByte(pixel.A);
-					}
-				}
+                for (int i = 0; i < height; i++)
+                {
+                    for (int j = 0; j < width; j++)
+                    {
+                        Color pixel = image.GetPixel(j, i);
+                        mspixels.WriteByte(pixel.B);
+                        mspixels.WriteByte(pixel.G);
+                        mspixels.WriteByte(pixel.R);
+                        mspixels.WriteByte(pixel.A);
+                    }
+                }
 
-				data = mspixels.ToArray();
+                data = mspixels.ToArray();
 
-				MemoryStream msx = new MemoryStream();
-				BinaryWriter bw = new BinaryWriter(msx);
+                MemoryStream msx = new MemoryStream();
+                BinaryWriter bw = new BinaryWriter(msx);
 
-				bw.Write((int)0);
-				bw.Write((int)0);
-				bw.Write((int)0);
-				bw.Write((int)1);
+                bw.Write((int)0);
+                bw.Write((int)0);
+                bw.Write((int)0);
+                bw.Write((int)1);
 
-				bw.Write((int)0x15);
-				bw.Write((short)width);
-				bw.Write((short)height);
+                bw.Write((int)0x15);
+                bw.Write((short)width);
+                bw.Write((short)height);
 
-				bw.Write((int)0x15);
-				bw.Write((int)0);
+                bw.Write((int)0x15);
+                bw.Write((int)0);
 
-				bw.Flush();
+                bw.Flush();
 
-				header = msx.ToArray();
+                header = msx.ToArray();
 
-				bw.Close();
-			}
-			else
-			{
+                bw.Close();
+            }
+            else
+            {
 
-				DXTCompression dxt = DXTCompression.DXT1;
-				if (compression == CompressionType.DXT3)
-					dxt = DXTCompression.DXT1;
-				else if (compression == CompressionType.DXT5)
-					dxt = DXTCompression.DXT5;
-				data = ImageUtil.CompressImage(newImage, dxt);
+                DXTCompression dxt = DXTCompression.DXT1;
+                if (compression == CompressionType.DXT3)
+                    dxt = DXTCompression.DXT1;
+                else if (compression == CompressionType.DXT5)
+                    dxt = DXTCompression.DXT5;
+                data = ImageUtil.CompressImage(newImage, dxt);
 
-				MemoryStream msx = new MemoryStream();
-				BinaryWriter bw = new BinaryWriter(msx);
+                MemoryStream msx = new MemoryStream();
+                BinaryWriter bw = new BinaryWriter(msx);
 
-				bw.Write((int)0);
-				bw.Write((int)0);
-				bw.Write((int)0);
-				bw.Write((int)1);
+                bw.Write((int)0);
+                bw.Write((int)0);
+                bw.Write((int)0);
+                bw.Write((int)1);
 
-				bw.Write(Encoding.ASCII.GetBytes(compression.ToString()));
-				bw.Write((short)width);
-				bw.Write((short)height);
-				bw.Write((int)0x15);
-				bw.Write((int)0);
+                bw.Write(Encoding.ASCII.GetBytes(compression.ToString()));
+                bw.Write((short)width);
+                bw.Write((short)height);
+                bw.Write((int)0x15);
+                bw.Write((int)0);
 
-				bw.Flush();
+                bw.Flush();
 
-				header = msx.ToArray();
+                header = msx.ToArray();
 
-				bw.Close();
-			}
+                bw.Close();
+            }
 
             return new ImageInfo(header, data);
         }
 
-		public static ImageHeader GetImageHeader(byte[] data)
-		{
-			try
-			{
-				MemoryStream ms = new MemoryStream(data);
-				BinaryReader br = new BinaryReader(ms);
-				if (data.Length == 0x40 || data.Length == 0x30)
-				{
-					// Remaster
-					br.BaseStream.Seek(8, SeekOrigin.Begin);
-					uint unk1 = br.ReadUInt32();
-					uint unk2 = br.ReadUInt32();
+        public static ImageHeader GetImageHeader(byte[] data)
+        {
+            try
+            {
+                MemoryStream ms = new MemoryStream(data);
+                BinaryReader br = new BinaryReader(ms);
+                if (data.Length == 0x40 || data.Length == 0x30)
+                {
+                    // Remaster
+                    br.BaseStream.Seek(8, SeekOrigin.Begin);
+                    uint unk1 = br.ReadUInt32();
+                    uint unk2 = br.ReadUInt32();
 
-					br.BaseStream.Seek(0x1C, SeekOrigin.Begin);
+                    br.BaseStream.Seek(0x1C, SeekOrigin.Begin);
 
-					CompressionType type = CompressionType.UNKNOWN;
-					byte[] compression = br.ReadBytes(4);
-					string compressionString = Encoding.ASCII.GetString(compression);
-					if (compression.Matches(new byte[] { 0x15, 0x00, 0x00, 0x00 }))
-					{
-						type = CompressionType.BGRA;
-					}
-					else if (compression.Matches(new byte[] { 0x1C, 0x00, 0x00, 0x00 }))
-					{
-						type = CompressionType.RGBA;
-					}
-					else if (compression.Matches(new byte[] { 0xFF, 0x00, 0x00, 0x00 }))
-					{
-						type = CompressionType.ARGB;
-					}
-					else if (compression.Matches(new byte[] { 0x47, 0x00, 0x00, 0x00 }))
-					{
-						type = CompressionType.DXT1;
-					}
-					else if (compression.Matches(new byte[] { 0x4A, 0x00, 0x00, 0x00 }))
-					{
-						type = CompressionType.DXT3;
-					}
-					else if (compression.Matches(new byte[] { 0x4D, 0x00, 0x00, 0x00 }))
-					{
-						type = CompressionType.DXT5;
-					}
+                    CompressionType type = CompressionType.UNKNOWN;
+                    byte[] compression = br.ReadBytes(4);
+                    string compressionString = Encoding.ASCII.GetString(compression);
+                    if (compression.Matches(new byte[] { 0x15, 0x00, 0x00, 0x00 }))
+                    {
+                        type = CompressionType.BGRA;
+                    }
+                    else if (compression.Matches(new byte[] { 0x1C, 0x00, 0x00, 0x00 }))
+                    {
+                        type = CompressionType.RGBA;
+                    }
+                    else if (compression.Matches(new byte[] { 0xFF, 0x00, 0x00, 0x00 }))
+                    {
+                        type = CompressionType.ARGB;
+                    }
+                    else if (compression.Matches(new byte[] { 0x47, 0x00, 0x00, 0x00 }))
+                    {
+                        type = CompressionType.DXT1;
+                    }
+                    else if (compression.Matches(new byte[] { 0x4A, 0x00, 0x00, 0x00 }))
+                    {
+                        type = CompressionType.DXT3;
+                    }
+                    else if (compression.Matches(new byte[] { 0x4D, 0x00, 0x00, 0x00 }))
+                    {
+                        type = CompressionType.DXT5;
+                    }
 
-					uint unk3 = br.ReadUInt32();
+                    uint unk3 = br.ReadUInt32();
 
-					int width = br.ReadInt16();
-					int height = br.ReadInt16();
-					br.Close();
+                    int width = br.ReadInt16();
+                    int height = br.ReadInt16();
+                    br.Close();
 
-					return new ImageHeader(type, width, height);
-				}
-				else
-				{
-					// OLD PC
-					br.BaseStream.Seek(0x10, SeekOrigin.Begin);
-					CompressionType type = CompressionType.UNKNOWN;
-					byte[] compression = br.ReadBytes(4);
-					string compressionString = Encoding.ASCII.GetString(compression);
-					if (compression.Matches(new byte[] { 0x15, 0x00, 0x00, 0x00 }))
-					{
-						type = CompressionType.BGRA;
-					}
-					else if (compression.Matches(new byte[] { 0xFF, 0x00, 0x00, 0x00 }))
-					{
-						type = CompressionType.ARGB;
-					}
-					else if (compressionString.StartsWith("DXT"))
-					{
-						switch (compressionString[3])
-						{
-							case '1':
-								type = CompressionType.DXT1;
-								break;
-							case '3':
-								type = CompressionType.DXT3;
-								break;
-							case '5':
-								type = CompressionType.DXT5;
-								break;
-						}
-					}
+                    return new ImageHeader(type, width, height);
+                }
+                else
+                {
+                    // OLD PC
+                    br.BaseStream.Seek(0x10, SeekOrigin.Begin);
+                    CompressionType type = CompressionType.UNKNOWN;
+                    byte[] compression = br.ReadBytes(4);
+                    string compressionString = Encoding.ASCII.GetString(compression);
+                    if (compression.Matches(new byte[] { 0x15, 0x00, 0x00, 0x00 }))
+                    {
+                        type = CompressionType.BGRA;
+                    }
+                    else if (compression.Matches(new byte[] { 0xFF, 0x00, 0x00, 0x00 }))
+                    {
+                        type = CompressionType.ARGB;
+                    }
+                    else if (compressionString.StartsWith("DXT"))
+                    {
+                        switch (compressionString[3])
+                        {
+                            case '1':
+                                type = CompressionType.DXT1;
+                                break;
+                            case '3':
+                                type = CompressionType.DXT3;
+                                break;
+                            case '5':
+                                type = CompressionType.DXT5;
+                                break;
+                        }
+                    }
 
-					int width = br.ReadInt16();
-					int height = br.ReadInt16();
-					br.Close();
+                    int width = br.ReadInt16();
+                    int height = br.ReadInt16();
+                    br.Close();
 
-					return new ImageHeader(type, width, height);
-				}
-			}
-			catch (Exception ex)
-			{
-				MessageBox.Show(ex.Message + "\r\n" + ex.StackTrace);
-			}
+                    return new ImageHeader(type, width, height);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message + "\r\n" + ex.StackTrace);
+            }
 
-			return null;
-		}
+            return null;
+        }
 
-	    public static Image GetImage(byte[] data, byte[] extraData)
-	    {
-		    try
-			{
-				ImageHeader header = GetImageHeader(data);
-				byte[] pixels = extraData;
+        public static Image GetImage(byte[] data, byte[] extraData)
+        {
+            try
+            {
+                ImageHeader header = GetImageHeader(data);
+                byte[] pixels = extraData;
 
-				if (header.CompressionType == CompressionType.DXT1)
-				{
-					pixels = ImageUtil.DecompressImage(pixels, header.Width, header.Height, DXTCompression.DXT1);
-				}
-				else if (header.CompressionType == CompressionType.DXT3)
-				{
-					pixels = ImageUtil.DecompressImage(pixels, header.Width, header.Height, DXTCompression.DXT3);
-				}
-				else if (header.CompressionType == CompressionType.DXT5)
-				{
-					pixels = ImageUtil.DecompressImage(pixels, header.Width, header.Height, DXTCompression.DXT5);
-				}
+                if (header.CompressionType == CompressionType.DXT1)
+                {
+                    pixels = ImageUtil.DecompressImage(pixels, header.Width, header.Height, DXTCompression.DXT1);
+                }
+                else if (header.CompressionType == CompressionType.DXT3)
+                {
+                    pixels = ImageUtil.DecompressImage(pixels, header.Width, header.Height, DXTCompression.DXT3);
+                }
+                else if (header.CompressionType == CompressionType.DXT5)
+                {
+                    pixels = ImageUtil.DecompressImage(pixels, header.Width, header.Height, DXTCompression.DXT5);
+                }
 
-				DirectBitmap bitmap = new DirectBitmap(header.Width, header.Height);
+                DirectBitmap bitmap = new DirectBitmap(header.Width, header.Height);
 
-				int index = 0;
-				for (int y = 0; y < header.Height; y++)
-				{
-					for (int x = 0; x < header.Width; x++)
-					{
-						byte red;
-						byte green;
-						byte blue;
-						byte alpha;
-						if (header.CompressionType == CompressionType.BGRA)
-						{
-							blue = pixels[index + 0];
-							green = pixels[index + 1];
-							red = pixels[index + 2];
-							alpha = pixels[index + 3];
-						}
-						else if (header.CompressionType == CompressionType.RGBA)
-						{
-							red = pixels[index + 0];
-							green = pixels[index + 1];
-							blue = pixels[index + 2];
-							alpha = pixels[index + 3];
-						} else 
-						{
-							alpha = pixels[index + 0];
-							red = pixels[index + 1];
-							green = pixels[index + 2];
-							blue = pixels[index + 3];
-						}
+                int index = 0;
+                for (int y = 0; y < header.Height; y++)
+                {
+                    for (int x = 0; x < header.Width; x++)
+                    {
+                        byte red;
+                        byte green;
+                        byte blue;
+                        byte alpha;
+                        if (header.CompressionType == CompressionType.BGRA)
+                        {
+                            blue = pixels[index + 0];
+                            green = pixels[index + 1];
+                            red = pixels[index + 2];
+                            alpha = pixels[index + 3];
+                        }
+                        else if (header.CompressionType == CompressionType.RGBA)
+                        {
+                            red = pixels[index + 0];
+                            green = pixels[index + 1];
+                            blue = pixels[index + 2];
+                            alpha = pixels[index + 3];
+                        } else 
+                        {
+                            alpha = pixels[index + 0];
+                            red = pixels[index + 1];
+                            green = pixels[index + 2];
+                            blue = pixels[index + 3];
+                        }
 
-						Color color = Color.FromArgb(alpha, red, green, blue);
-						bitmap.Bits[x + y * header.Width] = color.ToArgb();
-						index += 4;
-					}
-				}
+                        Color color = Color.FromArgb(alpha, red, green, blue);
+                        bitmap.Bits[x + y * header.Width] = color.ToArgb();
+                        index += 4;
+                    }
+                }
 
-				return bitmap.Bitmap;
-		    }
-		    catch (Exception ex)
-		    {
-			    MessageBox.Show(ex.Message + "\r\n" + ex.StackTrace);
-			    return null;
-		    }
-	    }
+                return bitmap.Bitmap;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message + "\r\n" + ex.StackTrace);
+                return null;
+            }
+        }
 
-	    public static Image GetImagePS3(byte[] data, byte[] extraData)
+        public static Image GetImagePS3(byte[] data, byte[] extraData)
         {
             if (extraData != null && data.Length == 48)
             {
@@ -356,7 +356,7 @@ namespace BurnoutImage
                             }
 
                             Color color = Color.FromArgb(alpha, red, green, blue);
-							bitmap.Bits[x + y * width] = color.ToArgb();
+                            bitmap.Bits[x + y * width] = color.ToArgb();
                             bitmap.SetPixel(x, y, color);
                             index += 4;
                         }
@@ -375,16 +375,16 @@ namespace BurnoutImage
                 return null;
             }
         }
-	}
+    }
 
-	public enum CompressionType
-	{
-		RGBA,
-		ARGB,
-		BGRA,
-		DXT1,
-		DXT3,
-		DXT5,
-		UNKNOWN
-	}
+    public enum CompressionType
+    {
+        RGBA,
+        ARGB,
+        BGRA,
+        DXT1,
+        DXT3,
+        DXT5,
+        UNKNOWN
+    }
 }

--- a/IconLibrary/IconHelper.cs
+++ b/IconLibrary/IconHelper.cs
@@ -5,236 +5,236 @@ using System.Runtime.InteropServices;
 
 namespace IconLibrary
 {
-	/// <summary>
-	/// Provides static methods to read system icons for both folders and files.
-	/// </summary>
-	/// <example>
-	/// <code>IconReader.GetFileIcon("c:\\general.xls");</code>
-	/// </example>
-	public class IconReader
-	{
-		/// <summary>
-		/// Options to specify the size of icons to return.
-		/// </summary>
-		public enum IconSize
-		{
-			/// <summary>
-			/// Specify large icon - 32 pixels by 32 pixels.
-			/// </summary>
-			Large = 0,
-			/// <summary>
-			/// Specify small icon - 16 pixels by 16 pixels.
-			/// </summary>
-			Small = 1
-		}
+    /// <summary>
+    /// Provides static methods to read system icons for both folders and files.
+    /// </summary>
+    /// <example>
+    /// <code>IconReader.GetFileIcon("c:\\general.xls");</code>
+    /// </example>
+    public class IconReader
+    {
+        /// <summary>
+        /// Options to specify the size of icons to return.
+        /// </summary>
+        public enum IconSize
+        {
+            /// <summary>
+            /// Specify large icon - 32 pixels by 32 pixels.
+            /// </summary>
+            Large = 0,
+            /// <summary>
+            /// Specify small icon - 16 pixels by 16 pixels.
+            /// </summary>
+            Small = 1
+        }
         
-		/// <summary>
-		/// Options to specify whether folders should be in the open or closed state.
-		/// </summary>
-		public enum FolderType
-		{
-			/// <summary>
-			/// Specify open folder.
-			/// </summary>
-			Open = 0,
-			/// <summary>
-			/// Specify closed folder.
-			/// </summary>
-			Closed = 1
-		}
+        /// <summary>
+        /// Options to specify whether folders should be in the open or closed state.
+        /// </summary>
+        public enum FolderType
+        {
+            /// <summary>
+            /// Specify open folder.
+            /// </summary>
+            Open = 0,
+            /// <summary>
+            /// Specify closed folder.
+            /// </summary>
+            Closed = 1
+        }
 
-		/// <summary>
-		/// Returns an icon for a given file - indicated by the name parameter.
-		/// </summary>
-		/// <param name="name">Pathname for file.</param>
-		/// <param name="size">Large or small</param>
-		/// <param name="linkOverlay">Whether to include the link icon</param>
-		/// <returns>System.Drawing.Icon</returns>
-		public static System.Drawing.Icon GetFileIcon(string name, IconSize size, bool linkOverlay)
-		{
-			Shell32.SHFILEINFO shfi = new Shell32.SHFILEINFO();
-			uint flags = Shell32.SHGFI_ICON | Shell32.SHGFI_USEFILEATTRIBUTES;
+        /// <summary>
+        /// Returns an icon for a given file - indicated by the name parameter.
+        /// </summary>
+        /// <param name="name">Pathname for file.</param>
+        /// <param name="size">Large or small</param>
+        /// <param name="linkOverlay">Whether to include the link icon</param>
+        /// <returns>System.Drawing.Icon</returns>
+        public static System.Drawing.Icon GetFileIcon(string name, IconSize size, bool linkOverlay)
+        {
+            Shell32.SHFILEINFO shfi = new Shell32.SHFILEINFO();
+            uint flags = Shell32.SHGFI_ICON | Shell32.SHGFI_USEFILEATTRIBUTES;
 
-			if (true == linkOverlay) flags += Shell32.SHGFI_LINKOVERLAY;
+            if (true == linkOverlay) flags += Shell32.SHGFI_LINKOVERLAY;
 
-			/* Check the size specified for return. */
-			if (IconSize.Small == size)
-			{
-				flags += Shell32.SHGFI_SMALLICON ;
-			} 
-			else 
-			{
-				flags += Shell32.SHGFI_LARGEICON ;
-			}
+            /* Check the size specified for return. */
+            if (IconSize.Small == size)
+            {
+                flags += Shell32.SHGFI_SMALLICON ;
+            } 
+            else 
+            {
+                flags += Shell32.SHGFI_LARGEICON ;
+            }
 
-			Shell32.SHGetFileInfo(	name, 
-				Shell32.FILE_ATTRIBUTE_NORMAL, 
-				ref shfi, 
-				(uint) System.Runtime.InteropServices.Marshal.SizeOf(shfi), 
-				flags );
+            Shell32.SHGetFileInfo(    name, 
+                Shell32.FILE_ATTRIBUTE_NORMAL, 
+                ref shfi, 
+                (uint) System.Runtime.InteropServices.Marshal.SizeOf(shfi), 
+                flags );
 
-			// Copy (clone) the returned icon to a new object, thus allowing us to clean-up properly
-			System.Drawing.Icon icon = (System.Drawing.Icon)System.Drawing.Icon.FromHandle(shfi.hIcon).Clone();
-			User32.DestroyIcon( shfi.hIcon );		// Cleanup
-			return icon;
-		}
+            // Copy (clone) the returned icon to a new object, thus allowing us to clean-up properly
+            System.Drawing.Icon icon = (System.Drawing.Icon)System.Drawing.Icon.FromHandle(shfi.hIcon).Clone();
+            User32.DestroyIcon( shfi.hIcon );        // Cleanup
+            return icon;
+        }
 
-		/// <summary>
-		/// Used to access system folder icons.
-		/// </summary>
-		/// <param name="size">Specify large or small icons.</param>
-		/// <param name="folderType">Specify open or closed FolderType.</param>
-		/// <returns>System.Drawing.Icon</returns>
-		public static System.Drawing.Icon GetFolderIcon( IconSize size, FolderType folderType )
-		{
-			// Need to add size check, although errors generated at present!
-			uint flags = Shell32.SHGFI_ICON | Shell32.SHGFI_USEFILEATTRIBUTES;
+        /// <summary>
+        /// Used to access system folder icons.
+        /// </summary>
+        /// <param name="size">Specify large or small icons.</param>
+        /// <param name="folderType">Specify open or closed FolderType.</param>
+        /// <returns>System.Drawing.Icon</returns>
+        public static System.Drawing.Icon GetFolderIcon( IconSize size, FolderType folderType )
+        {
+            // Need to add size check, although errors generated at present!
+            uint flags = Shell32.SHGFI_ICON | Shell32.SHGFI_USEFILEATTRIBUTES;
 
-			if (FolderType.Open == folderType)
-			{
-				flags += Shell32.SHGFI_OPENICON;
-			}
-			
-			if (IconSize.Small == size)
-			{
-				flags += Shell32.SHGFI_SMALLICON;
-			} 
-			else 
-			{
-				flags += Shell32.SHGFI_LARGEICON;
-			}
+            if (FolderType.Open == folderType)
+            {
+                flags += Shell32.SHGFI_OPENICON;
+            }
+            
+            if (IconSize.Small == size)
+            {
+                flags += Shell32.SHGFI_SMALLICON;
+            } 
+            else 
+            {
+                flags += Shell32.SHGFI_LARGEICON;
+            }
 
-			// Get the folder icon
-			Shell32.SHFILEINFO shfi = new Shell32.SHFILEINFO();
-			Shell32.SHGetFileInfo(	null, 
-				Shell32.FILE_ATTRIBUTE_DIRECTORY, 
-				ref shfi, 
-				(uint) System.Runtime.InteropServices.Marshal.SizeOf(shfi), 
-				flags );
+            // Get the folder icon
+            Shell32.SHFILEINFO shfi = new Shell32.SHFILEINFO();
+            Shell32.SHGetFileInfo(    null, 
+                Shell32.FILE_ATTRIBUTE_DIRECTORY, 
+                ref shfi, 
+                (uint) System.Runtime.InteropServices.Marshal.SizeOf(shfi), 
+                flags );
 
-			System.Drawing.Icon.FromHandle(shfi.hIcon);	// Load the icon from an HICON handle
+            System.Drawing.Icon.FromHandle(shfi.hIcon);    // Load the icon from an HICON handle
 
-			// Now clone the icon, so that it can be successfully stored in an ImageList
-			System.Drawing.Icon icon = (System.Drawing.Icon)System.Drawing.Icon.FromHandle(shfi.hIcon).Clone();
+            // Now clone the icon, so that it can be successfully stored in an ImageList
+            System.Drawing.Icon icon = (System.Drawing.Icon)System.Drawing.Icon.FromHandle(shfi.hIcon).Clone();
 
-			User32.DestroyIcon( shfi.hIcon );		// Cleanup
-			return icon;
-		}	
-	}
+            User32.DestroyIcon( shfi.hIcon );        // Cleanup
+            return icon;
+        }    
+    }
 
-	/// <summary>
-	/// Wraps necessary Shell32.dll structures and functions required to retrieve Icon Handles using SHGetFileInfo. Code
-	/// courtesy of MSDN Cold Rooster Consulting case study.
-	/// </summary>
-	/// 
+    /// <summary>
+    /// Wraps necessary Shell32.dll structures and functions required to retrieve Icon Handles using SHGetFileInfo. Code
+    /// courtesy of MSDN Cold Rooster Consulting case study.
+    /// </summary>
+    /// 
 
-	// This code has been left largely untouched from that in the CRC example. The main changes have been moving
-	// the icon reading code over to the IconReader type.
-	public class Shell32  
-	{
-		
-		public const int 	MAX_PATH = 256;
-		[StructLayout(LayoutKind.Sequential)]
-			public struct SHITEMID
-		{
-			public ushort cb;
-			[MarshalAs(UnmanagedType.LPArray)]
-			public byte[] abID;
-		}
+    // This code has been left largely untouched from that in the CRC example. The main changes have been moving
+    // the icon reading code over to the IconReader type.
+    public class Shell32  
+    {
+        
+        public const int     MAX_PATH = 256;
+        [StructLayout(LayoutKind.Sequential)]
+            public struct SHITEMID
+        {
+            public ushort cb;
+            [MarshalAs(UnmanagedType.LPArray)]
+            public byte[] abID;
+        }
 
-		[StructLayout(LayoutKind.Sequential)]
-			public struct ITEMIDLIST
-		{
-			public SHITEMID mkid;
-		}
+        [StructLayout(LayoutKind.Sequential)]
+            public struct ITEMIDLIST
+        {
+            public SHITEMID mkid;
+        }
 
-		[StructLayout(LayoutKind.Sequential)]
-			public struct BROWSEINFO 
-		{ 
-			public IntPtr		hwndOwner; 
-			public IntPtr		pidlRoot; 
-			public IntPtr 		pszDisplayName;
-			[MarshalAs(UnmanagedType.LPTStr)] 
-			public string 		lpszTitle; 
-			public uint 		ulFlags; 
-			public IntPtr		lpfn; 
-			public int			lParam; 
-			public IntPtr 		iImage; 
-		} 
+        [StructLayout(LayoutKind.Sequential)]
+            public struct BROWSEINFO 
+        { 
+            public IntPtr        hwndOwner; 
+            public IntPtr        pidlRoot; 
+            public IntPtr         pszDisplayName;
+            [MarshalAs(UnmanagedType.LPTStr)] 
+            public string         lpszTitle; 
+            public uint         ulFlags; 
+            public IntPtr        lpfn; 
+            public int            lParam; 
+            public IntPtr         iImage; 
+        } 
 
-		// Browsing for directory.
-		public const uint BIF_RETURNONLYFSDIRS   =	0x0001;
-		public const uint BIF_DONTGOBELOWDOMAIN  =	0x0002;
-		public const uint BIF_STATUSTEXT         =	0x0004;
-		public const uint BIF_RETURNFSANCESTORS  =	0x0008;
-		public const uint BIF_EDITBOX            =	0x0010;
-		public const uint BIF_VALIDATE           =	0x0020;
-		public const uint BIF_NEWDIALOGSTYLE     =	0x0040;
-		public const uint BIF_USENEWUI           =	(BIF_NEWDIALOGSTYLE | BIF_EDITBOX);
-		public const uint BIF_BROWSEINCLUDEURLS  =	0x0080;
-		public const uint BIF_BROWSEFORCOMPUTER  =	0x1000;
-		public const uint BIF_BROWSEFORPRINTER   =	0x2000;
-		public const uint BIF_BROWSEINCLUDEFILES =	0x4000;
-		public const uint BIF_SHAREABLE          =	0x8000;
+        // Browsing for directory.
+        public const uint BIF_RETURNONLYFSDIRS   =    0x0001;
+        public const uint BIF_DONTGOBELOWDOMAIN  =    0x0002;
+        public const uint BIF_STATUSTEXT         =    0x0004;
+        public const uint BIF_RETURNFSANCESTORS  =    0x0008;
+        public const uint BIF_EDITBOX            =    0x0010;
+        public const uint BIF_VALIDATE           =    0x0020;
+        public const uint BIF_NEWDIALOGSTYLE     =    0x0040;
+        public const uint BIF_USENEWUI           =    (BIF_NEWDIALOGSTYLE | BIF_EDITBOX);
+        public const uint BIF_BROWSEINCLUDEURLS  =    0x0080;
+        public const uint BIF_BROWSEFORCOMPUTER  =    0x1000;
+        public const uint BIF_BROWSEFORPRINTER   =    0x2000;
+        public const uint BIF_BROWSEINCLUDEFILES =    0x4000;
+        public const uint BIF_SHAREABLE          =    0x8000;
 
-		[StructLayout(LayoutKind.Sequential)]
-			public struct SHFILEINFO
-		{ 
-			public const int NAMESIZE = 80;
-			public IntPtr	hIcon; 
-			public int		iIcon; 
-			public uint	dwAttributes; 
-			[MarshalAs(UnmanagedType.ByValTStr, SizeConst=MAX_PATH)]
-			public string szDisplayName; 
-			[MarshalAs(UnmanagedType.ByValTStr, SizeConst=NAMESIZE)]
-			public string szTypeName; 
-		};
+        [StructLayout(LayoutKind.Sequential)]
+            public struct SHFILEINFO
+        { 
+            public const int NAMESIZE = 80;
+            public IntPtr    hIcon; 
+            public int        iIcon; 
+            public uint    dwAttributes; 
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst=MAX_PATH)]
+            public string szDisplayName; 
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst=NAMESIZE)]
+            public string szTypeName; 
+        };
 
-		public const uint SHGFI_ICON				= 0x000000100;     // get icon
-		public const uint SHGFI_DISPLAYNAME			= 0x000000200;     // get display name
-		public const uint SHGFI_TYPENAME          	= 0x000000400;     // get type name
-		public const uint SHGFI_ATTRIBUTES        	= 0x000000800;     // get attributes
-		public const uint SHGFI_ICONLOCATION      	= 0x000001000;     // get icon location
-		public const uint SHGFI_EXETYPE           	= 0x000002000;     // return exe type
-		public const uint SHGFI_SYSICONINDEX      	= 0x000004000;     // get system icon index
-		public const uint SHGFI_LINKOVERLAY       	= 0x000008000;     // put a link overlay on icon
-		public const uint SHGFI_SELECTED          	= 0x000010000;     // show icon in selected state
-		public const uint SHGFI_ATTR_SPECIFIED    	= 0x000020000;     // get only specified attributes
-		public const uint SHGFI_LARGEICON         	= 0x000000000;     // get large icon
-		public const uint SHGFI_SMALLICON         	= 0x000000001;     // get small icon
-		public const uint SHGFI_OPENICON          	= 0x000000002;     // get open icon
-		public const uint SHGFI_SHELLICONSIZE     	= 0x000000004;     // get shell size icon
-		public const uint SHGFI_PIDL              	= 0x000000008;     // pszPath is a pidl
-		public const uint SHGFI_USEFILEATTRIBUTES 	= 0x000000010;     // use passed dwFileAttribute
-		public const uint SHGFI_ADDOVERLAYS       	= 0x000000020;     // apply the appropriate overlays
-		public const uint SHGFI_OVERLAYINDEX      	= 0x000000040;     // Get the index of the overlay
+        public const uint SHGFI_ICON                = 0x000000100;     // get icon
+        public const uint SHGFI_DISPLAYNAME            = 0x000000200;     // get display name
+        public const uint SHGFI_TYPENAME              = 0x000000400;     // get type name
+        public const uint SHGFI_ATTRIBUTES            = 0x000000800;     // get attributes
+        public const uint SHGFI_ICONLOCATION          = 0x000001000;     // get icon location
+        public const uint SHGFI_EXETYPE               = 0x000002000;     // return exe type
+        public const uint SHGFI_SYSICONINDEX          = 0x000004000;     // get system icon index
+        public const uint SHGFI_LINKOVERLAY           = 0x000008000;     // put a link overlay on icon
+        public const uint SHGFI_SELECTED              = 0x000010000;     // show icon in selected state
+        public const uint SHGFI_ATTR_SPECIFIED        = 0x000020000;     // get only specified attributes
+        public const uint SHGFI_LARGEICON             = 0x000000000;     // get large icon
+        public const uint SHGFI_SMALLICON             = 0x000000001;     // get small icon
+        public const uint SHGFI_OPENICON              = 0x000000002;     // get open icon
+        public const uint SHGFI_SHELLICONSIZE         = 0x000000004;     // get shell size icon
+        public const uint SHGFI_PIDL                  = 0x000000008;     // pszPath is a pidl
+        public const uint SHGFI_USEFILEATTRIBUTES     = 0x000000010;     // use passed dwFileAttribute
+        public const uint SHGFI_ADDOVERLAYS           = 0x000000020;     // apply the appropriate overlays
+        public const uint SHGFI_OVERLAYINDEX          = 0x000000040;     // Get the index of the overlay
 
-		public const uint FILE_ATTRIBUTE_DIRECTORY  = 0x00000010;  
-		public const uint FILE_ATTRIBUTE_NORMAL     = 0x00000080;  
+        public const uint FILE_ATTRIBUTE_DIRECTORY  = 0x00000010;  
+        public const uint FILE_ATTRIBUTE_NORMAL     = 0x00000080;  
 
-		[DllImport("Shell32.dll")]
-		public static extern IntPtr SHGetFileInfo(
-			string pszPath,
-			uint dwFileAttributes,
-			ref SHFILEINFO psfi,
-			uint cbFileInfo,
-			uint uFlags
-			);
-	}
+        [DllImport("Shell32.dll")]
+        public static extern IntPtr SHGetFileInfo(
+            string pszPath,
+            uint dwFileAttributes,
+            ref SHFILEINFO psfi,
+            uint cbFileInfo,
+            uint uFlags
+            );
+    }
 
-	/// <summary>
-	/// Wraps necessary functions imported from User32.dll. Code courtesy of MSDN Cold Rooster Consulting example.
-	/// </summary>
-	public class User32
-	{
-		/// <summary>
-		/// Provides access to function required to delete handle. This method is used internally
-		/// and is not required to be called separately.
-		/// </summary>
-		/// <param name="hIcon">Pointer to icon handle.</param>
-		/// <returns>N/A</returns>
-		[DllImport("User32.dll")]
-		public static extern int DestroyIcon( IntPtr hIcon );
-	}
+    /// <summary>
+    /// Wraps necessary functions imported from User32.dll. Code courtesy of MSDN Cold Rooster Consulting example.
+    /// </summary>
+    public class User32
+    {
+        /// <summary>
+        /// Provides access to function required to delete handle. This method is used internally
+        /// and is not required to be called separately.
+        /// </summary>
+        /// <param name="hIcon">Pointer to icon handle.</param>
+        /// <returns>N/A</returns>
+        [DllImport("User32.dll")]
+        public static extern int DestroyIcon( IntPtr hIcon );
+    }
 }
 

--- a/IconLibrary/IconHelper.cs
+++ b/IconLibrary/IconHelper.cs
@@ -67,7 +67,7 @@ namespace IconLibrary
                 flags += Shell32.SHGFI_LARGEICON ;
             }
 
-            Shell32.SHGetFileInfo(    name, 
+            Shell32.SHGetFileInfo(name, 
                 Shell32.FILE_ATTRIBUTE_NORMAL, 
                 ref shfi, 
                 (uint) System.Runtime.InteropServices.Marshal.SizeOf(shfi), 
@@ -75,7 +75,7 @@ namespace IconLibrary
 
             // Copy (clone) the returned icon to a new object, thus allowing us to clean-up properly
             System.Drawing.Icon icon = (System.Drawing.Icon)System.Drawing.Icon.FromHandle(shfi.hIcon).Clone();
-            User32.DestroyIcon( shfi.hIcon );        // Cleanup
+            User32.DestroyIcon( shfi.hIcon ); // Cleanup
             return icon;
         }
 
@@ -106,18 +106,18 @@ namespace IconLibrary
 
             // Get the folder icon
             Shell32.SHFILEINFO shfi = new Shell32.SHFILEINFO();
-            Shell32.SHGetFileInfo(    null, 
+            Shell32.SHGetFileInfo(null, 
                 Shell32.FILE_ATTRIBUTE_DIRECTORY, 
                 ref shfi, 
                 (uint) System.Runtime.InteropServices.Marshal.SizeOf(shfi), 
                 flags );
 
-            System.Drawing.Icon.FromHandle(shfi.hIcon);    // Load the icon from an HICON handle
+            System.Drawing.Icon.FromHandle(shfi.hIcon); // Load the icon from an HICON handle
 
             // Now clone the icon, so that it can be successfully stored in an ImageList
             System.Drawing.Icon icon = (System.Drawing.Icon)System.Drawing.Icon.FromHandle(shfi.hIcon).Clone();
 
-            User32.DestroyIcon( shfi.hIcon );        // Cleanup
+            User32.DestroyIcon( shfi.hIcon ); // Cleanup
             return icon;
         }    
     }
@@ -133,7 +133,7 @@ namespace IconLibrary
     public class Shell32  
     {
         
-        public const int     MAX_PATH = 256;
+        public const int MAX_PATH = 256;
         [StructLayout(LayoutKind.Sequential)]
             public struct SHITEMID
         {
@@ -151,66 +151,66 @@ namespace IconLibrary
         [StructLayout(LayoutKind.Sequential)]
             public struct BROWSEINFO 
         { 
-            public IntPtr        hwndOwner; 
-            public IntPtr        pidlRoot; 
-            public IntPtr         pszDisplayName;
+            public IntPtr hwndOwner; 
+            public IntPtr pidlRoot; 
+            public IntPtr pszDisplayName;
             [MarshalAs(UnmanagedType.LPTStr)] 
-            public string         lpszTitle; 
-            public uint         ulFlags; 
-            public IntPtr        lpfn; 
-            public int            lParam; 
-            public IntPtr         iImage; 
+            public string lpszTitle; 
+            public uint ulFlags; 
+            public IntPtr lpfn; 
+            public int lParam; 
+            public IntPtr iImage; 
         } 
 
         // Browsing for directory.
-        public const uint BIF_RETURNONLYFSDIRS   =    0x0001;
-        public const uint BIF_DONTGOBELOWDOMAIN  =    0x0002;
-        public const uint BIF_STATUSTEXT         =    0x0004;
-        public const uint BIF_RETURNFSANCESTORS  =    0x0008;
-        public const uint BIF_EDITBOX            =    0x0010;
-        public const uint BIF_VALIDATE           =    0x0020;
-        public const uint BIF_NEWDIALOGSTYLE     =    0x0040;
-        public const uint BIF_USENEWUI           =    (BIF_NEWDIALOGSTYLE | BIF_EDITBOX);
-        public const uint BIF_BROWSEINCLUDEURLS  =    0x0080;
-        public const uint BIF_BROWSEFORCOMPUTER  =    0x1000;
-        public const uint BIF_BROWSEFORPRINTER   =    0x2000;
-        public const uint BIF_BROWSEINCLUDEFILES =    0x4000;
-        public const uint BIF_SHAREABLE          =    0x8000;
+        public const uint BIF_RETURNONLYFSDIRS   = 0x0001;
+        public const uint BIF_DONTGOBELOWDOMAIN  = 0x0002;
+        public const uint BIF_STATUSTEXT         = 0x0004;
+        public const uint BIF_RETURNFSANCESTORS  = 0x0008;
+        public const uint BIF_EDITBOX            = 0x0010;
+        public const uint BIF_VALIDATE           = 0x0020;
+        public const uint BIF_NEWDIALOGSTYLE     = 0x0040;
+        public const uint BIF_USENEWUI           = (BIF_NEWDIALOGSTYLE | BIF_EDITBOX);
+        public const uint BIF_BROWSEINCLUDEURLS  = 0x0080;
+        public const uint BIF_BROWSEFORCOMPUTER  = 0x1000;
+        public const uint BIF_BROWSEFORPRINTER   = 0x2000;
+        public const uint BIF_BROWSEINCLUDEFILES = 0x4000;
+        public const uint BIF_SHAREABLE          = 0x8000;
 
         [StructLayout(LayoutKind.Sequential)]
             public struct SHFILEINFO
         { 
             public const int NAMESIZE = 80;
-            public IntPtr    hIcon; 
-            public int        iIcon; 
-            public uint    dwAttributes; 
+            public IntPtr hIcon; 
+            public int iIcon; 
+            public uint dwAttributes; 
             [MarshalAs(UnmanagedType.ByValTStr, SizeConst=MAX_PATH)]
             public string szDisplayName; 
             [MarshalAs(UnmanagedType.ByValTStr, SizeConst=NAMESIZE)]
             public string szTypeName; 
         };
 
-        public const uint SHGFI_ICON                = 0x000000100;     // get icon
-        public const uint SHGFI_DISPLAYNAME            = 0x000000200;     // get display name
-        public const uint SHGFI_TYPENAME              = 0x000000400;     // get type name
-        public const uint SHGFI_ATTRIBUTES            = 0x000000800;     // get attributes
-        public const uint SHGFI_ICONLOCATION          = 0x000001000;     // get icon location
-        public const uint SHGFI_EXETYPE               = 0x000002000;     // return exe type
-        public const uint SHGFI_SYSICONINDEX          = 0x000004000;     // get system icon index
-        public const uint SHGFI_LINKOVERLAY           = 0x000008000;     // put a link overlay on icon
-        public const uint SHGFI_SELECTED              = 0x000010000;     // show icon in selected state
-        public const uint SHGFI_ATTR_SPECIFIED        = 0x000020000;     // get only specified attributes
-        public const uint SHGFI_LARGEICON             = 0x000000000;     // get large icon
-        public const uint SHGFI_SMALLICON             = 0x000000001;     // get small icon
-        public const uint SHGFI_OPENICON              = 0x000000002;     // get open icon
-        public const uint SHGFI_SHELLICONSIZE         = 0x000000004;     // get shell size icon
-        public const uint SHGFI_PIDL                  = 0x000000008;     // pszPath is a pidl
-        public const uint SHGFI_USEFILEATTRIBUTES     = 0x000000010;     // use passed dwFileAttribute
-        public const uint SHGFI_ADDOVERLAYS           = 0x000000020;     // apply the appropriate overlays
-        public const uint SHGFI_OVERLAYINDEX          = 0x000000040;     // Get the index of the overlay
+        public const uint SHGFI_ICON              = 0x000000100; // get icon
+        public const uint SHGFI_DISPLAYNAME       = 0x000000200; // get display name
+        public const uint SHGFI_TYPENAME          = 0x000000400; // get type name
+        public const uint SHGFI_ATTRIBUTES        = 0x000000800; // get attributes
+        public const uint SHGFI_ICONLOCATION      = 0x000001000; // get icon location
+        public const uint SHGFI_EXETYPE           = 0x000002000; // return exe type
+        public const uint SHGFI_SYSICONINDEX      = 0x000004000; // get system icon index
+        public const uint SHGFI_LINKOVERLAY       = 0x000008000; // put a link overlay on icon
+        public const uint SHGFI_SELECTED          = 0x000010000; // show icon in selected state
+        public const uint SHGFI_ATTR_SPECIFIED    = 0x000020000; // get only specified attributes
+        public const uint SHGFI_LARGEICON         = 0x000000000; // get large icon
+        public const uint SHGFI_SMALLICON         = 0x000000001; // get small icon
+        public const uint SHGFI_OPENICON          = 0x000000002; // get open icon
+        public const uint SHGFI_SHELLICONSIZE     = 0x000000004; // get shell size icon
+        public const uint SHGFI_PIDL              = 0x000000008; // pszPath is a pidl
+        public const uint SHGFI_USEFILEATTRIBUTES = 0x000000010; // use passed dwFileAttribute
+        public const uint SHGFI_ADDOVERLAYS       = 0x000000020; // apply the appropriate overlays
+        public const uint SHGFI_OVERLAYINDEX      = 0x000000040; // Get the index of the overlay
 
-        public const uint FILE_ATTRIBUTE_DIRECTORY  = 0x00000010;  
-        public const uint FILE_ATTRIBUTE_NORMAL     = 0x00000080;  
+        public const uint FILE_ATTRIBUTE_DIRECTORY = 0x00000010;
+        public const uint FILE_ATTRIBUTE_NORMAL    = 0x00000080;
 
         [DllImport("Shell32.dll")]
         public static extern IntPtr SHGetFileInfo(

--- a/IconLibrary/IconListManager.cs
+++ b/IconLibrary/IconListManager.cs
@@ -6,110 +6,110 @@ using System.Windows.Forms;
 
 namespace IconLibrary
 {
-	/// <summary>
-	/// Maintains a list of currently added file extensions
-	/// </summary>
-	public class IconListManager
-	{
-		private Hashtable _extensionList = new Hashtable();
-		private System.Collections.ArrayList _imageLists = new ArrayList();			//will hold ImageList objects
-		private IconReader.IconSize _iconSize;
-		bool ManageBothSizes = false; //flag, used to determine whether to create two ImageLists.
+    /// <summary>
+    /// Maintains a list of currently added file extensions
+    /// </summary>
+    public class IconListManager
+    {
+        private Hashtable _extensionList = new Hashtable();
+        private System.Collections.ArrayList _imageLists = new ArrayList();            //will hold ImageList objects
+        private IconReader.IconSize _iconSize;
+        bool ManageBothSizes = false; //flag, used to determine whether to create two ImageLists.
 
-		/// <summary>
-		/// Creates an instance of <c>IconListManager</c> that will add icons to a single <c>ImageList</c> using the
-		/// specified <c>IconSize</c>.
-		/// </summary>
-		/// <param name="imageList"><c>ImageList</c> to add icons to.</param>
-		/// <param name="iconSize">Size to use (either 32 or 16 pixels).</param>
-		public IconListManager(System.Windows.Forms.ImageList imageList, IconReader.IconSize iconSize )
-		{
-			// Initialise the members of the class that will hold the image list we're
-			// targeting, as well as the icon size (32 or 16)
+        /// <summary>
+        /// Creates an instance of <c>IconListManager</c> that will add icons to a single <c>ImageList</c> using the
+        /// specified <c>IconSize</c>.
+        /// </summary>
+        /// <param name="imageList"><c>ImageList</c> to add icons to.</param>
+        /// <param name="iconSize">Size to use (either 32 or 16 pixels).</param>
+        public IconListManager(System.Windows.Forms.ImageList imageList, IconReader.IconSize iconSize )
+        {
+            // Initialise the members of the class that will hold the image list we're
+            // targeting, as well as the icon size (32 or 16)
             _imageLists.Add( imageList );
-			_iconSize = iconSize;
-		}
-		
-		/// <summary>
-		/// Creates an instance of IconListManager that will add icons to two <c>ImageList</c> types. The two
-		/// image lists are intended to be one for large icons, and the other for small icons.
-		/// </summary>
-		/// <param name="smallImageList">The <c>ImageList</c> that will hold small icons.</param>
-		/// <param name="largeImageList">The <c>ImageList</c> that will hold large icons.</param>
-		public IconListManager(System.Windows.Forms.ImageList smallImageList, System.Windows.Forms.ImageList largeImageList )
-		{
-			//add both our image lists
-			_imageLists.Add( smallImageList );
-			_imageLists.Add( largeImageList );
+            _iconSize = iconSize;
+        }
+        
+        /// <summary>
+        /// Creates an instance of IconListManager that will add icons to two <c>ImageList</c> types. The two
+        /// image lists are intended to be one for large icons, and the other for small icons.
+        /// </summary>
+        /// <param name="smallImageList">The <c>ImageList</c> that will hold small icons.</param>
+        /// <param name="largeImageList">The <c>ImageList</c> that will hold large icons.</param>
+        public IconListManager(System.Windows.Forms.ImageList smallImageList, System.Windows.Forms.ImageList largeImageList )
+        {
+            //add both our image lists
+            _imageLists.Add( smallImageList );
+            _imageLists.Add( largeImageList );
 
-			//set flag
-			ManageBothSizes = true;
-		}
+            //set flag
+            ManageBothSizes = true;
+        }
 
-		/// <summary>
-		/// Used internally, adds the extension to the hashtable, so that its value can then be returned.
-		/// </summary>
-		/// <param name="Extension"><c>String</c> of the file's extension.</param>
-		/// <param name="ImageListPosition">Position of the extension in the <c>ImageList</c>.</param>
-		private void AddExtension( string Extension, int ImageListPosition )
-		{
-			_extensionList.Add( Extension, ImageListPosition );
-		}
+        /// <summary>
+        /// Used internally, adds the extension to the hashtable, so that its value can then be returned.
+        /// </summary>
+        /// <param name="Extension"><c>String</c> of the file's extension.</param>
+        /// <param name="ImageListPosition">Position of the extension in the <c>ImageList</c>.</param>
+        private void AddExtension( string Extension, int ImageListPosition )
+        {
+            _extensionList.Add( Extension, ImageListPosition );
+        }
 
-		/// <summary>
-		/// Called publicly to add a file's icon to the ImageList.
-		/// </summary>
-		/// <param name="filePath">Full path to the file.</param>
-		/// <returns>Integer of the icon's position in the ImageList</returns>
-		public int AddFileIcon( string filePath )
-		{
-			// Check if the file exists, otherwise, throw exception.
-			if (!System.IO.File.Exists( filePath ) && !System.IO.Directory.Exists( filePath )) throw new System.IO.FileNotFoundException("File does not exist");
-			
-			// Split it down so we can get the extension
-			string[] splitPath = filePath.Split(new Char[] {'.'});
-			string extension = (string)splitPath.GetValue( splitPath.GetUpperBound(0) );
-				
-			//Check that we haven't already got the extension, if we have, then
-			//return back its index
-			if (_extensionList.ContainsKey( extension.ToUpper() ))
-			{
-				return (int)_extensionList[extension.ToUpper()];		//return existing index
-			} 
-			else 
-			{
-				// It's not already been added, so add it and record its position.
+        /// <summary>
+        /// Called publicly to add a file's icon to the ImageList.
+        /// </summary>
+        /// <param name="filePath">Full path to the file.</param>
+        /// <returns>Integer of the icon's position in the ImageList</returns>
+        public int AddFileIcon( string filePath )
+        {
+            // Check if the file exists, otherwise, throw exception.
+            if (!System.IO.File.Exists( filePath ) && !System.IO.Directory.Exists( filePath )) throw new System.IO.FileNotFoundException("File does not exist");
+            
+            // Split it down so we can get the extension
+            string[] splitPath = filePath.Split(new Char[] {'.'});
+            string extension = (string)splitPath.GetValue( splitPath.GetUpperBound(0) );
+                
+            //Check that we haven't already got the extension, if we have, then
+            //return back its index
+            if (_extensionList.ContainsKey( extension.ToUpper() ))
+            {
+                return (int)_extensionList[extension.ToUpper()];        //return existing index
+            } 
+            else 
+            {
+                // It's not already been added, so add it and record its position.
 
-				int pos = ((ImageList)_imageLists[0]).Images.Count;		//store current count -- new item's index
+                int pos = ((ImageList)_imageLists[0]).Images.Count;        //store current count -- new item's index
 
-				if (ManageBothSizes == true)
-				{
-					//managing two lists, so add it to small first, then large
-					((ImageList)_imageLists[0]).Images.Add( IconReader.GetFileIcon( filePath, IconReader.IconSize.Small, false ) );
-					((ImageList)_imageLists[1]).Images.Add( IconReader.GetFileIcon( filePath, IconReader.IconSize.Large, false ) );
-				} 
-				else
-				{
-					//only doing one size, so use IconSize as specified in _iconSize.
-					((ImageList)_imageLists[0]).Images.Add( IconReader.GetFileIcon( filePath, _iconSize, false ) );	//add to image list
-				}
+                if (ManageBothSizes == true)
+                {
+                    //managing two lists, so add it to small first, then large
+                    ((ImageList)_imageLists[0]).Images.Add( IconReader.GetFileIcon( filePath, IconReader.IconSize.Small, false ) );
+                    ((ImageList)_imageLists[1]).Images.Add( IconReader.GetFileIcon( filePath, IconReader.IconSize.Large, false ) );
+                } 
+                else
+                {
+                    //only doing one size, so use IconSize as specified in _iconSize.
+                    ((ImageList)_imageLists[0]).Images.Add( IconReader.GetFileIcon( filePath, _iconSize, false ) );    //add to image list
+                }
 
-				AddExtension( extension.ToUpper(), pos );	// add to hash table
-				return pos;
-			}
-		}
+                AddExtension( extension.ToUpper(), pos );    // add to hash table
+                return pos;
+            }
+        }
 
-		/// <summary>
-		/// Clears any <c>ImageLists</c> that <c>IconListManager</c> is managing.
-		/// </summary>
-		public void ClearLists()
-		{
-			foreach( ImageList imageList in _imageLists )
-			{
-				imageList.Images.Clear();	//clear current imagelist.
-			}
-			
-			_extensionList.Clear();			//empty hashtable of entries too.
-		}
-	}
+        /// <summary>
+        /// Clears any <c>ImageLists</c> that <c>IconListManager</c> is managing.
+        /// </summary>
+        public void ClearLists()
+        {
+            foreach( ImageList imageList in _imageLists )
+            {
+                imageList.Images.Clear();    //clear current imagelist.
+            }
+            
+            _extensionList.Clear();            //empty hashtable of entries too.
+        }
+    }
 }

--- a/IconLibrary/IconListManager.cs
+++ b/IconLibrary/IconListManager.cs
@@ -12,7 +12,7 @@ namespace IconLibrary
     public class IconListManager
     {
         private Hashtable _extensionList = new Hashtable();
-        private System.Collections.ArrayList _imageLists = new ArrayList();            //will hold ImageList objects
+        private System.Collections.ArrayList _imageLists = new ArrayList(); //will hold ImageList objects
         private IconReader.IconSize _iconSize;
         bool ManageBothSizes = false; //flag, used to determine whether to create two ImageLists.
 
@@ -74,13 +74,13 @@ namespace IconLibrary
             //return back its index
             if (_extensionList.ContainsKey( extension.ToUpper() ))
             {
-                return (int)_extensionList[extension.ToUpper()];        //return existing index
+                return (int)_extensionList[extension.ToUpper()]; //return existing index
             } 
             else 
             {
                 // It's not already been added, so add it and record its position.
 
-                int pos = ((ImageList)_imageLists[0]).Images.Count;        //store current count -- new item's index
+                int pos = ((ImageList)_imageLists[0]).Images.Count; //store current count -- new item's index
 
                 if (ManageBothSizes == true)
                 {
@@ -91,10 +91,10 @@ namespace IconLibrary
                 else
                 {
                     //only doing one size, so use IconSize as specified in _iconSize.
-                    ((ImageList)_imageLists[0]).Images.Add( IconReader.GetFileIcon( filePath, _iconSize, false ) );    //add to image list
+                    ((ImageList)_imageLists[0]).Images.Add( IconReader.GetFileIcon( filePath, _iconSize, false ) ); //add to image list
                 }
 
-                AddExtension( extension.ToUpper(), pos );    // add to hash table
+                AddExtension( extension.ToUpper(), pos ); // add to hash table
                 return pos;
             }
         }
@@ -106,10 +106,10 @@ namespace IconLibrary
         {
             foreach( ImageList imageList in _imageLists )
             {
-                imageList.Images.Clear();    //clear current imagelist.
+                imageList.Images.Clear(); //clear current imagelist.
             }
             
-            _extensionList.Clear();            //empty hashtable of entries too.
+            _extensionList.Clear(); //empty hashtable of entries too.
         }
     }
 }

--- a/LangEditor/LangPlugin.cs
+++ b/LangEditor/LangPlugin.cs
@@ -8,21 +8,21 @@ using System.Threading.Tasks;
 
 namespace LangEditor
 {
-	public class LangPlugin : Plugin
-	{
-		public override void Init()
-		{
-			EntryTypeRegistry.Register(EntryType.Language, new Language());
-		}
+    public class LangPlugin : Plugin
+    {
+        public override void Init()
+        {
+            EntryTypeRegistry.Register(EntryType.Language, new Language());
+        }
 
-		public override string GetID()
-		{
-			return "langplugin";
-		}
+        public override string GetID()
+        {
+            return "langplugin";
+        }
 
-		public override string GetName()
-		{
-			return "Language Resource Handler";
-		}
-	}
+        public override string GetName()
+        {
+            return "Language Resource Handler";
+        }
+    }
 }

--- a/LangEditor/Language.cs
+++ b/LangEditor/Language.cs
@@ -21,17 +21,17 @@ namespace LangEditor
             Data = new Dictionary<uint, string>();
         }
 
-		private void Clear()
-		{
-			Unknown1 = default;
-			Unknown2 = default;
+        private void Clear()
+        {
+            Unknown1 = default;
+            Unknown2 = default;
 
-			Data.Clear();
-		}
+            Data.Clear();
+        }
 
         public bool Read(BundleEntry entry, ILoader loader = null)
         {
-			Clear();
+            Clear();
 
             MemoryStream ms = entry.MakeStream();
             BinaryReader2 br = new BinaryReader2(ms);
@@ -119,24 +119,24 @@ namespace LangEditor
             return true;
         }
 
-		public EntryType GetEntryType(BundleEntry entry)
-		{
-			return EntryType.Language;
-		}
+        public EntryType GetEntryType(BundleEntry entry)
+        {
+            return EntryType.Language;
+        }
 
-		public IEntryEditor GetEditor(BundleEntry entry)
-		{
-			LangEdit edit = new LangEdit();
-			edit.Lang = this;
-			edit.Changed += () =>
-			{
-				edit.Lang.Write(entry);
+        public IEntryEditor GetEditor(BundleEntry entry)
+        {
+            LangEdit edit = new LangEdit();
+            edit.Lang = this;
+            edit.Changed += () =>
+            {
+                edit.Lang.Write(entry);
             };
 
-			return edit;
-		}
+            return edit;
+        }
 
-		public static uint HashID(string id)
+        public static uint HashID(string id)
         {
             /*uint result = 0xFFFFFFFF;
             for (int i = 0; i < id.Length; i++)
@@ -167,5 +167,5 @@ namespace LangEditor
 
             return hash;
         }
-	}
+    }
 }

--- a/MathLib/IOExtensions.cs
+++ b/MathLib/IOExtensions.cs
@@ -74,23 +74,23 @@ namespace MathLib
             self.Write(value.Z);
         }
 
-		public static Vector2I ReadVector2I(this BinaryReader self)
-		{
-			Vector2I result = new Vector2I();
+        public static Vector2I ReadVector2I(this BinaryReader self)
+        {
+            Vector2I result = new Vector2I();
 
-			result.X = self.ReadInt32();
-			result.Y = self.ReadInt32();
+            result.X = self.ReadInt32();
+            result.Y = self.ReadInt32();
 
-			return result;
-		}
+            return result;
+        }
 
-		public static void Write(this BinaryWriter self, Vector2I value)
-		{
-			self.Write(value.X);
-			self.Write(value.Y);
-		}
+        public static void Write(this BinaryWriter self, Vector2I value)
+        {
+            self.Write(value.X);
+            self.Write(value.Y);
+        }
 
-		public static Vector3S ReadVector3S(this BinaryReader self)
+        public static Vector3S ReadVector3S(this BinaryReader self)
         {
             Vector3S result = new Vector3S();
 

--- a/MathLib/MathUtils.cs
+++ b/MathLib/MathUtils.cs
@@ -7,30 +7,30 @@ using System.Threading.Tasks;
 
 namespace MathLib
 {
-	public static class MathUtils
-	{
-		public static Vector3 MinBounds(params Vector3[] points)
-		{
-			Vector3 result = new Vector3(points[0].X, points[0].Y, points[0].Z);
-			for (int i = 1; i < points.Length; i++)
-			{
-				result.X = Math.Min(points[i].X, result.X);
-				result.Y = Math.Min(points[i].Y, result.Y);
-				result.Z = Math.Min(points[i].Z, result.Z);
-			}
-			return result;
-		}
+    public static class MathUtils
+    {
+        public static Vector3 MinBounds(params Vector3[] points)
+        {
+            Vector3 result = new Vector3(points[0].X, points[0].Y, points[0].Z);
+            for (int i = 1; i < points.Length; i++)
+            {
+                result.X = Math.Min(points[i].X, result.X);
+                result.Y = Math.Min(points[i].Y, result.Y);
+                result.Z = Math.Min(points[i].Z, result.Z);
+            }
+            return result;
+        }
 
-		public static Vector3 MaxBounds(params Vector3[] points)
-		{
-			Vector3 result = new Vector3(points[0].X, points[0].Y, points[0].Z);
-			for (int i = 1; i < points.Length; i++)
-			{
-				result.X = Math.Max(points[i].X, result.X);
-				result.Y = Math.Max(points[i].Y, result.Y);
-				result.Z = Math.Max(points[i].Z, result.Z);
-			}
-			return result;
-		}
-	}
+        public static Vector3 MaxBounds(params Vector3[] points)
+        {
+            Vector3 result = new Vector3(points[0].X, points[0].Y, points[0].Z);
+            for (int i = 1; i < points.Length; i++)
+            {
+                result.X = Math.Max(points[i].X, result.X);
+                result.Y = Math.Max(points[i].Y, result.Y);
+                result.Z = Math.Max(points[i].Z, result.Z);
+            }
+            return result;
+        }
+    }
 }

--- a/ModelViewer/ModelViewerForm.cs
+++ b/ModelViewer/ModelViewerForm.cs
@@ -16,7 +16,7 @@ namespace ModelViewer
 {
     public partial class ModelViewerForm : Form, IEntryEditor
     {
-		public SceneRenderControl Renderer => rndMain;
+        public SceneRenderControl Renderer => rndMain;
 
         public ModelViewerForm()
         {

--- a/ModelViewer/SceneData/Mesh.cs
+++ b/ModelViewer/SceneData/Mesh.cs
@@ -262,36 +262,36 @@ namespace ModelViewer.SceneData
 
             if (Material?.DiffuseMap != null)
             {
-				try
-				{
-					int width = Material.DiffuseMap.Width;
-					int height = Material.DiffuseMap.Height;
+                try
+                {
+                    int width = Material.DiffuseMap.Width;
+                    int height = Material.DiffuseMap.Height;
 
-					_texture = GL.GenTexture();
-					GL.BindTexture(TextureTarget.Texture2D, _texture);
-					GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)All.Linear);
-					GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)All.Linear);
+                    _texture = GL.GenTexture();
+                    GL.BindTexture(TextureTarget.Texture2D, _texture);
+                    GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)All.Linear);
+                    GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)All.Linear);
 
-					GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba, width, height, 0, PixelFormat.Bgra,
-						PixelType.UnsignedByte, IntPtr.Zero);
-					Bitmap bitmap = new Bitmap(Material.DiffuseMap);
-					BitmapData data = bitmap.LockBits(new Rectangle(0, 0, width, height), ImageLockMode.ReadOnly,
-						System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+                    GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba, width, height, 0, PixelFormat.Bgra,
+                        PixelType.UnsignedByte, IntPtr.Zero);
+                    Bitmap bitmap = new Bitmap(Material.DiffuseMap);
+                    BitmapData data = bitmap.LockBits(new Rectangle(0, 0, width, height), ImageLockMode.ReadOnly,
+                        System.Drawing.Imaging.PixelFormat.Format32bppArgb);
 
-					GL.TexSubImage2D(TextureTarget.Texture2D, 0, 0, 0, width, height, PixelFormat.Bgra,
-						PixelType.UnsignedByte, data.Scan0);
+                    GL.TexSubImage2D(TextureTarget.Texture2D, 0, 0, 0, width, height, PixelFormat.Bgra,
+                        PixelType.UnsignedByte, data.Scan0);
 
-					bitmap.UnlockBits(data);
+                    bitmap.UnlockBits(data);
 
-					bitmap.Dispose();
+                    bitmap.Dispose();
 
-					GL.BindTexture(TextureTarget.Texture2D, 0);
+                    GL.BindTexture(TextureTarget.Texture2D, 0);
 
-					GL.Enable(EnableCap.Texture2D);
-				} catch (ArgumentException ex)
-				{
-					Console.WriteLine(ex.Message + "\n\n" + ex.StackTrace);
-				}
+                    GL.Enable(EnableCap.Texture2D);
+                } catch (ArgumentException ex)
+                {
+                    Console.WriteLine(ex.Message + "\n\n" + ex.StackTrace);
+                }
             }
             else
             {

--- a/PVSFormat/PVS.cs
+++ b/PVSFormat/PVS.cs
@@ -17,21 +17,21 @@ namespace PVSFormat
         public float X;
         public float Y;
         public int Padding1; // Padding???
-		public int Padding2; // Padding???
+        public int Padding2; // Padding???
 
-		public override string ToString()
+        public override string ToString()
         {
             return "X: " + X + ", Y: " + Y + ", Padding1: " + Padding1 + ", Padding2: " + Padding2;
         }
     }
 
-	public enum NeighbourFlags
-	{
-		E_RENDERFLAG_NONE = 0x0,
-		E_NEIGHBOURFLAG_RENDER = 0x1,
-		E_NEIGHBOURFLAG_IMMEDIATE = 0x2,
-		E_NEIGHBOURFLAG_RENDER_IMMEDIATE = 0x3,
-	}
+    public enum NeighbourFlags
+    {
+        E_RENDERFLAG_NONE = 0x0,
+        E_NEIGHBOURFLAG_RENDER = 0x1,
+        E_NEIGHBOURFLAG_IMMEDIATE = 0x2,
+        E_NEIGHBOURFLAG_RENDER_IMMEDIATE = 0x3,
+    }
 
     public struct ZoneNeighbour
     {
@@ -39,9 +39,9 @@ namespace PVSFormat
         public uint NeighborPtr;
         public NeighbourFlags Flags;
         public int Padding1; // Padding???
-		public int Padding2; // Padding???
+        public int Padding2; // Padding???
 
-		public override string ToString()
+        public override string ToString()
         {
             return "NeighborIndex: " + NeighborIndex + ", Type: " + Flags + ", Unk1: " + Padding1 + ", Unk2: " + Padding2;
         }
@@ -55,16 +55,16 @@ namespace PVSFormat
         public uint UnsafeNeighboursPtr;
         public uint Unknown;
         public long ZoneID;
-		public short ZoneType;
-		public short NumPoints;
+        public short ZoneType;
+        public short NumPoints;
         public short NumSafeNeighbours;
         public short NumUnsafeNeighbours;
         public int Flags;
         public int Padding1; // Padding???
-		public int Padding2; // Padding???
-		public int Padding3; // Padding???
+        public int Padding2; // Padding???
+        public int Padding3; // Padding???
 
-		public List<ZonePoint> Points;
+        public List<ZonePoint> Points;
         public List<ZoneNeighbour> UnsafeNeighbours;
 
         public override string ToString()
@@ -75,54 +75,54 @@ namespace PVSFormat
 
     public class PVS : IEntryData
     {
-		private Image _gameMap;
+        private Image _gameMap;
 
-		public uint PointsPtr;
-		public uint ZonePtr;
-		public uint ZonePointStart1;
-		public uint ZonePointStart2;
-		public uint ZonePointCount;
-		public uint TotalZones;
+        public uint PointsPtr;
+        public uint ZonePtr;
+        public uint ZonePointStart1;
+        public uint ZonePointStart2;
+        public uint ZonePointCount;
+        public uint TotalZones;
         public uint TotalPoints;
-		public uint Padding; // Padding???
-		public List<PVSZone> Zones;
+        public uint Padding; // Padding???
+        public List<PVSZone> Zones;
 
         public PVS()
         {
             Zones = new List<PVSZone>();
         }
 
-		private void Clear()
-		{
-			PointsPtr = default;
-			ZonePtr = default;
-			ZonePointStart1 = default;
-			ZonePointStart2 = default;
-			ZonePointCount = default;
-			TotalZones = default;
-			TotalPoints = default;
+        private void Clear()
+        {
+            PointsPtr = default;
+            ZonePtr = default;
+            ZonePointStart1 = default;
+            ZonePointStart2 = default;
+            ZonePointCount = default;
+            TotalZones = default;
+            TotalPoints = default;
 
-			Zones.Clear();
-		}
+            Zones.Clear();
+        }
 
         public bool Read(BundleEntry entry, ILoader loader)
         {
-			Clear();
+            Clear();
 
             Stream s = entry.MakeStream();
             BinaryReader2 br = new BinaryReader2(s);
             br.BigEndian = entry.Console;
 
-			PointsPtr = br.ReadUInt32();
-			ZonePtr = br.ReadUInt32();
+            PointsPtr = br.ReadUInt32();
+            ZonePtr = br.ReadUInt32();
 
-			ZonePointStart1 = br.ReadUInt32();
-			ZonePointStart2 = br.ReadUInt32();
+            ZonePointStart1 = br.ReadUInt32();
+            ZonePointStart2 = br.ReadUInt32();
 
-			ZonePointCount = br.ReadUInt32();
-			TotalZones = br.ReadUInt32();
+            ZonePointCount = br.ReadUInt32();
+            TotalZones = br.ReadUInt32();
             TotalPoints = br.ReadUInt32();
-			Padding = br.ReadUInt32();
+            Padding = br.ReadUInt32();
 
             for (uint i = 0; i < ZonePointCount; i++)
             {
@@ -134,13 +134,13 @@ namespace PVSFormat
                 pvsEntry.UnsafeNeighboursPtr = br.ReadUInt32();
                 pvsEntry.Unknown = br.ReadUInt32();
                 pvsEntry.ZoneID = br.ReadInt64();
-				pvsEntry.ZoneType = br.ReadInt16();
-				pvsEntry.NumPoints = br.ReadInt16();
-				pvsEntry.NumSafeNeighbours = br.ReadInt16();
+                pvsEntry.ZoneType = br.ReadInt16();
+                pvsEntry.NumPoints = br.ReadInt16();
+                pvsEntry.NumSafeNeighbours = br.ReadInt16();
                 pvsEntry.NumUnsafeNeighbours = br.ReadInt16();
                 pvsEntry.Flags = br.ReadInt32();
                 pvsEntry.Padding1 = br.ReadInt32();
-				pvsEntry.Padding2 = br.ReadInt32();
+                pvsEntry.Padding2 = br.ReadInt32();
                 pvsEntry.Padding3 = br.ReadInt32();
 
                 long pos = br.BaseStream.Position;
@@ -203,66 +203,66 @@ namespace PVSFormat
             br.Close();
             s.Close();
 
-			_gameMap = GetGameMap(entry.Archive);
+            _gameMap = GetGameMap(entry.Archive);
 
             return true;
         }
 
-		public bool Write(BundleEntry entry)
+        public bool Write(BundleEntry entry)
         {
             return true;
         }
 
-		public EntryType GetEntryType(BundleEntry entry)
-		{
-			return EntryType.ZoneList;
-		}
+        public EntryType GetEntryType(BundleEntry entry)
+        {
+            return EntryType.ZoneList;
+        }
 
-		public IEntryEditor GetEditor(BundleEntry entry)
-		{
-			PVSEditor pvsForm = new PVSEditor();
-			pvsForm.GameMap = _gameMap;
-			pvsForm.Open(this);
+        public IEntryEditor GetEditor(BundleEntry entry)
+        {
+            PVSEditor pvsForm = new PVSEditor();
+            pvsForm.GameMap = _gameMap;
+            pvsForm.Open(this);
 
-			return pvsForm;
-		}
+            return pvsForm;
+        }
 
-		private Image GetGameMap(BundleArchive archive)
-		{
-			ulong id = 0x9F55039D;
-			BundleEntry descEntry1 = archive.GetEntryByID(id);
-			if (descEntry1 == null)
-			{
-				string file = BundleCache.GetFileByEntryID(id);
-				if (!string.IsNullOrEmpty(file))
-				{
-					BundleArchive archive2 = BundleArchive.Read(file);
-					if (archive2 != null)
-						descEntry1 = archive2.GetEntryByID(id);
-				}
-			}
+        private Image GetGameMap(BundleArchive archive)
+        {
+            ulong id = 0x9F55039D;
+            BundleEntry descEntry1 = archive.GetEntryByID(id);
+            if (descEntry1 == null)
+            {
+                string file = BundleCache.GetFileByEntryID(id);
+                if (!string.IsNullOrEmpty(file))
+                {
+                    BundleArchive archive2 = BundleArchive.Read(file);
+                    if (archive2 != null)
+                        descEntry1 = archive2.GetEntryByID(id);
+                }
+            }
 
-			if (descEntry1 == null)
-			{
-				string path = Path.GetDirectoryName(archive.Path) + Path.DirectorySeparatorChar + "GUITEXTURES.BIN";
-				BundleArchive archive2 = BundleArchive.Read(path);
-				if (archive2 != null)
-					descEntry1 = archive2.GetEntryByID(id);
-			}
+            if (descEntry1 == null)
+            {
+                string path = Path.GetDirectoryName(archive.Path) + Path.DirectorySeparatorChar + "GUITEXTURES.BIN";
+                BundleArchive archive2 = BundleArchive.Read(path);
+                if (archive2 != null)
+                    descEntry1 = archive2.GetEntryByID(id);
+            }
 
-			Image image = null;
+            Image image = null;
 
-			if (descEntry1 != null && descEntry1.Type == EntryType.Texture)
-			{
-				if (archive.Console)
-					image = GameImage.GetImagePS3(descEntry1.EntryBlocks[0].Data, descEntry1.EntryBlocks[1].Data);
-				else
-					image = GameImage.GetImage(descEntry1.EntryBlocks[0].Data, descEntry1.EntryBlocks[1].Data);
+            if (descEntry1 != null && descEntry1.Type == EntryType.Texture)
+            {
+                if (archive.Console)
+                    image = GameImage.GetImagePS3(descEntry1.EntryBlocks[0].Data, descEntry1.EntryBlocks[1].Data);
+                else
+                    image = GameImage.GetImage(descEntry1.EntryBlocks[0].Data, descEntry1.EntryBlocks[1].Data);
 
-				if (image != null)
-					TextureCache.AddToCache(id, image);
-			}
-			return image;
-		}
-	}
+                if (image != null)
+                    TextureCache.AddToCache(id, image);
+            }
+            return image;
+        }
+    }
 }

--- a/PVSFormat/PVSEditControl.cs
+++ b/PVSFormat/PVSEditControl.cs
@@ -8,288 +8,288 @@ using System.Windows.Forms;
 
 namespace PVSFormat
 {
-	public class PVSEditControl : Control
-	{
-		private PVS _pvsFile;
-		public PVS PVS
-		{
-			get => _pvsFile;
-			set
-			{
-				_pvsFile = value;
-				OnPVSUpdated();
-			}
-		}
+    public class PVSEditControl : Control
+    {
+        private PVS _pvsFile;
+        public PVS PVS
+        {
+            get => _pvsFile;
+            set
+            {
+                _pvsFile = value;
+                OnPVSUpdated();
+            }
+        }
 
-		public Image GameMap;
+        public Image GameMap;
 
-		protected const float Multiplier = 0.1f;
+        protected const float Multiplier = 0.1f;
 
-		protected float RenderScale;
-		//protected float Zoom;
-		protected PointF CameraPosition;
-		protected PointF RenderOffset => new PointF(-CameraPosition.X + ClientRectangle.Width / 2.0f, -CameraPosition.Y + ClientRectangle.Height / 2.0f);
-		protected float MapSize => (RenderScale * 32);
-		protected bool isHand;
-		protected bool isDragging;
-		protected Point lastMouse;
-		protected Point mousePos;
+        protected float RenderScale;
+        //protected float Zoom;
+        protected PointF CameraPosition;
+        protected PointF RenderOffset => new PointF(-CameraPosition.X + ClientRectangle.Width / 2.0f, -CameraPosition.Y + ClientRectangle.Height / 2.0f);
+        protected float MapSize => (RenderScale * 32);
+        protected bool isHand;
+        protected bool isDragging;
+        protected Point lastMouse;
+        protected Point mousePos;
 
-		protected PointF MousePosOnMap
-		{
-			get
-			{
-				return new PointF((mousePos.X - ClientRectangle.Width / 2.0f + CameraPosition.X) / RenderScale / Multiplier, (mousePos.Y - ClientRectangle.Height / 2.0f + CameraPosition.Y) / RenderScale / Multiplier);
-			}
-		}
+        protected PointF MousePosOnMap
+        {
+            get
+            {
+                return new PointF((mousePos.X - ClientRectangle.Width / 2.0f + CameraPosition.X) / RenderScale / Multiplier, (mousePos.Y - ClientRectangle.Height / 2.0f + CameraPosition.Y) / RenderScale / Multiplier);
+            }
+        }
 
-		protected PointF ScaledMousePosOnMap
-		{
-			get
-			{
-				return new PointF(mousePos.X - ClientRectangle.Width / 2.0f + CameraPosition.X, mousePos.Y - ClientRectangle.Height / 2.0f + CameraPosition.Y);
-			}
-		}
+        protected PointF ScaledMousePosOnMap
+        {
+            get
+            {
+                return new PointF(mousePos.X - ClientRectangle.Width / 2.0f + CameraPosition.X, mousePos.Y - ClientRectangle.Height / 2.0f + CameraPosition.Y);
+            }
+        }
 
-		public PVSEditControl()
-		{
-			Width = 400;
-			Height = 300;
-			ForeColor = Color.White;
-			BackColor = Color.Black;
-			Font = new Font(FontFamily.GenericMonospace, 10.0f);
-			DoubleBuffered = true;
+        public PVSEditControl()
+        {
+            Width = 400;
+            Height = 300;
+            ForeColor = Color.White;
+            BackColor = Color.Black;
+            Font = new Font(FontFamily.GenericMonospace, 10.0f);
+            DoubleBuffered = true;
 
-			RenderScale = 1;
+            RenderScale = 1;
 
-			CameraPosition = new Point(0, 0);
-		}
+            CameraPosition = new Point(0, 0);
+        }
 
-		protected override void OnKeyDown(KeyEventArgs e)
-		{
-			if (e.KeyData == Keys.Space)
-			{
-				isHand = true;
-				UpdateCursor();
-			}
-			if (e.KeyData == Keys.Oemplus)
-			{
-				CameraPosition.X = 0;
-				CameraPosition.Y = 0;
-				Invalidate();
-			}
-		}
+        protected override void OnKeyDown(KeyEventArgs e)
+        {
+            if (e.KeyData == Keys.Space)
+            {
+                isHand = true;
+                UpdateCursor();
+            }
+            if (e.KeyData == Keys.Oemplus)
+            {
+                CameraPosition.X = 0;
+                CameraPosition.Y = 0;
+                Invalidate();
+            }
+        }
 
-		protected override void OnKeyUp(KeyEventArgs e)
-		{
-			if (e.KeyData == Keys.Space)
-			{
-				isHand = false;
-				lastMouse = new Point(0, 0);
-			}
+        protected override void OnKeyUp(KeyEventArgs e)
+        {
+            if (e.KeyData == Keys.Space)
+            {
+                isHand = false;
+                lastMouse = new Point(0, 0);
+            }
 
-			UpdateCursor();
-		}
+            UpdateCursor();
+        }
 
-		protected override void OnMouseDown(MouseEventArgs e)
-		{
-			if (e.Button == MouseButtons.Left)
-			{
-				lastMouse = e.Location;
+        protected override void OnMouseDown(MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Left)
+            {
+                lastMouse = e.Location;
 
-				if (isHand)
-				{
-					isDragging = true;
-				}
-			}
-		}
+                if (isHand)
+                {
+                    isDragging = true;
+                }
+            }
+        }
 
-		protected override void OnMouseUp(MouseEventArgs e)
-		{
-			if (e.Button == MouseButtons.Left)
-			{
-				isDragging = false;
-				lastMouse = new Point(0, 0);
-			}
-		}
+        protected override void OnMouseUp(MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Left)
+            {
+                isDragging = false;
+                lastMouse = new Point(0, 0);
+            }
+        }
 
-		protected override void OnMouseMove(MouseEventArgs e)
-		{
-			mousePos = e.Location;
-			Invalidate();
-			if (isHand && isDragging)
-			{
-				Size difference = new Size(e.X - lastMouse.X, e.Y - lastMouse.Y);
-				lastMouse = new Point(e.X, e.Y);
+        protected override void OnMouseMove(MouseEventArgs e)
+        {
+            mousePos = e.Location;
+            Invalidate();
+            if (isHand && isDragging)
+            {
+                Size difference = new Size(e.X - lastMouse.X, e.Y - lastMouse.Y);
+                lastMouse = new Point(e.X, e.Y);
 
-				CameraPosition -= difference;
-				Invalidate();
-			}
-		}
+                CameraPosition -= difference;
+                Invalidate();
+            }
+        }
 
-		protected override void OnMouseWheel(MouseEventArgs e)
-		{
-			int wheelDelta = 120;
+        protected override void OnMouseWheel(MouseEventArgs e)
+        {
+            int wheelDelta = 120;
 
-			float oldScale = RenderScale;
+            float oldScale = RenderScale;
 
-			RenderScale += (e.Delta * (RenderScale / 4)) / (wheelDelta * 1.0f);
+            RenderScale += (e.Delta * (RenderScale / 4)) / (wheelDelta * 1.0f);
 
-			if (RenderScale < 1)
-			{
-				RenderScale = oldScale;
-			}
-			else if (RenderScale > 500)
-			{
-				RenderScale = oldScale;
-			}
+            if (RenderScale < 1)
+            {
+                RenderScale = oldScale;
+            }
+            else if (RenderScale > 500)
+            {
+                RenderScale = oldScale;
+            }
 
-			if (oldScale != RenderScale)
-			{
-				CameraPosition.X += (ScaledMousePosOnMap.X / 4) * Math.Sign(e.Delta);
-				CameraPosition.Y += (ScaledMousePosOnMap.Y / 4) * Math.Sign(e.Delta);
-			}
+            if (oldScale != RenderScale)
+            {
+                CameraPosition.X += (ScaledMousePosOnMap.X / 4) * Math.Sign(e.Delta);
+                CameraPosition.Y += (ScaledMousePosOnMap.Y / 4) * Math.Sign(e.Delta);
+            }
 
-			Invalidate();
-		}
+            Invalidate();
+        }
 
-		protected void UpdateCursor()
-		{
-			Cursor = isHand ? Cursors.SizeAll : Cursors.Arrow;
-		}
+        protected void UpdateCursor()
+        {
+            Cursor = isHand ? Cursors.SizeAll : Cursors.Arrow;
+        }
 
-		protected override void OnPaint(PaintEventArgs e)
-		{
-			Graphics g = e.Graphics;
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            Graphics g = e.Graphics;
 
-			DrawMap(g);
-			DrawPVS(g);
-			DrawOverlay(g);
-		}
+            DrawMap(g);
+            DrawPVS(g);
+            DrawOverlay(g);
+        }
 
-		protected void DrawMap(Graphics g)
-		{
-			if (GameMap == null)
-				return;
+        protected void DrawMap(Graphics g)
+        {
+            if (GameMap == null)
+                return;
 
-			float x = -4148.0f; //-GameMap.Width / 2 + 4148.0f;// + 200 - 50;
-			float y = -5858.0f; //-GameMap.Height / 2 + 5858.0f;// - 400 - 250;
-			float width = 10200.0f;// - 4148.0f; //GameMap.Width;
-			float height = 9718.0f;// - 5858.0f; // GameMap.Height;
+            float x = -4148.0f; //-GameMap.Width / 2 + 4148.0f;// + 200 - 50;
+            float y = -5858.0f; //-GameMap.Height / 2 + 5858.0f;// - 400 - 250;
+            float width = 10200.0f;// - 4148.0f; //GameMap.Width;
+            float height = 9718.0f;// - 5858.0f; // GameMap.Height;
 
-			float mult = 0.1f;
+            float mult = 0.1f;
 
-			//x = x + RenderOffset.X;
-			//y = y + RenderOffset.Y;
+            //x = x + RenderOffset.X;
+            //y = y + RenderOffset.Y;
 
-			x = x * mult * RenderScale + RenderOffset.X;
-			y = y * mult * RenderScale + RenderOffset.Y;
-			width = width * mult * RenderScale;
-			height = height * mult * RenderScale;
+            x = x * mult * RenderScale + RenderOffset.X;
+            y = y * mult * RenderScale + RenderOffset.Y;
+            width = width * mult * RenderScale;
+            height = height * mult * RenderScale;
 
-			RectangleF rect = new RectangleF(x, y, width, height);
+            RectangleF rect = new RectangleF(x, y, width, height);
 
-			g.DrawImage(GameMap, rect);
-		}
+            g.DrawImage(GameMap, rect);
+        }
 
-		protected void DrawPVS(Graphics g)
-		{
-			if (PVS == null)
-				return;
+        protected void DrawPVS(Graphics g)
+        {
+            if (PVS == null)
+                return;
 
-			// Draw all plates
-			for (int i = 0; i < PVS.Zones.Count; i++)
-			{
-				PVSZone plate = PVS.Zones[i];
+            // Draw all plates
+            for (int i = 0; i < PVS.Zones.Count; i++)
+            {
+                PVSZone plate = PVS.Zones[i];
 
-				DrawMapSection(g, plate);
-			}
-		}
+                DrawMapSection(g, plate);
+            }
+        }
 
-		protected void DrawMapSection(Graphics g, PVSZone entry)
-		{
-			PointF[] points = new PointF[entry.Points.Count];
-			for (int i = 0; i < entry.Points.Count; i++)
-			{
-				ZonePoint data = entry.Points[i];
-				points[i] = new PointF(data.X * Multiplier * RenderScale + RenderOffset.X, data.Y * Multiplier * RenderScale + RenderOffset.Y);
-			}
+        protected void DrawMapSection(Graphics g, PVSZone entry)
+        {
+            PointF[] points = new PointF[entry.Points.Count];
+            for (int i = 0; i < entry.Points.Count; i++)
+            {
+                ZonePoint data = entry.Points[i];
+                points[i] = new PointF(data.X * Multiplier * RenderScale + RenderOffset.X, data.Y * Multiplier * RenderScale + RenderOffset.Y);
+            }
 
-			Polygon poly = new Polygon(points);
-			RectangleF bounds = poly.Bounds;
+            Polygon poly = new Polygon(points);
+            RectangleF bounds = poly.Bounds;
 
-			if (bounds.IntersectsWith(ClientRectangle))
-			{
+            if (bounds.IntersectsWith(ClientRectangle))
+            {
 
-				//g.FillPolygon(new SolidBrush(Color.IndianRed), points);
-				g.DrawPolygon(new Pen(Color.Cyan), points);
+                //g.FillPolygon(new SolidBrush(Color.IndianRed), points);
+                g.DrawPolygon(new Pen(Color.Cyan), points);
 
-				Font font;
+                Font font;
 
-				string infoText;
-				SizeF textSize;
+                string infoText;
+                SizeF textSize;
 
-				int times = 0;
+                int times = 0;
 
-				// Scale font to fit within rectangle
-				bool noRender = false;
-				do
-				{
-					if (RenderScale / Multiplier - times < 0.01f)
-					{
-						font = null;
-						infoText = null;
-						textSize = new SizeF();
-						noRender = true;
-						break;
-					}
-					float textScale = RenderScale / (Multiplier * 2) - times;
-					font = new Font(Font.FontFamily, textScale);
-					infoText = entry.ZoneID.ToString();
-					textSize = g.MeasureString(infoText, font);
+                // Scale font to fit within rectangle
+                bool noRender = false;
+                do
+                {
+                    if (RenderScale / Multiplier - times < 0.01f)
+                    {
+                        font = null;
+                        infoText = null;
+                        textSize = new SizeF();
+                        noRender = true;
+                        break;
+                    }
+                    float textScale = RenderScale / (Multiplier * 2) - times;
+                    font = new Font(Font.FontFamily, textScale);
+                    infoText = entry.ZoneID.ToString();
+                    textSize = g.MeasureString(infoText, font);
 
-					times++;
-				} while (textSize.Width > bounds.Width || textSize.Height > bounds.Height);
+                    times++;
+                } while (textSize.Width > bounds.Width || textSize.Height > bounds.Height);
 
-				if (!noRender)
-				{
-					// Render text
-					StringFormat format = new StringFormat(StringFormat.GenericDefault);
-					format.Alignment = StringAlignment.Center;
-					g.DrawString(infoText, font, new SolidBrush(ForeColor), bounds.X + bounds.Width / 2, bounds.Y + bounds.Height / 2 - textSize.Height / 2, format);
-				}
-			}
-		}
+                if (!noRender)
+                {
+                    // Render text
+                    StringFormat format = new StringFormat(StringFormat.GenericDefault);
+                    format.Alignment = StringAlignment.Center;
+                    g.DrawString(infoText, font, new SolidBrush(ForeColor), bounds.X + bounds.Width / 2, bounds.Y + bounds.Height / 2 - textSize.Height / 2, format);
+                }
+            }
+        }
 
-		protected void DrawOverlay(Graphics g)
-		{
-			// Render Overlay Text
-			string status = PVS == null ? "Nothing Loaded" : "Loaded";
-			g.DrawString(status, Font, new SolidBrush(ForeColor), 10, 10);
+        protected void DrawOverlay(Graphics g)
+        {
+            // Render Overlay Text
+            string status = PVS == null ? "Nothing Loaded" : "Loaded";
+            g.DrawString(status, Font, new SolidBrush(ForeColor), 10, 10);
 
-			g.DrawString("Zoom x" + (int)RenderScale, Font, new SolidBrush(ForeColor), 10, 25);
-			g.DrawString("Camera (" + CameraPosition.X + ", " + CameraPosition.Y + ")", Font, new SolidBrush(ForeColor), 10, 40);
-			g.DrawString("Mouse (" + mousePos.X + ", " + mousePos.Y + ")", Font, new SolidBrush(ForeColor), 10, 55);
-			//g.DrawString("Map Size " + MapSize + "px", Font, new SolidBrush(ForeColor), 10, 70);
-			g.DrawString("Mouse Pos On Map (" + MousePosOnMap.X + ", " + MousePosOnMap.Y + ")", Font, new SolidBrush(ForeColor), 10, 85);
-			//g.DrawString("Scaled Mouse Pos On Map (" + ScaledMousePosOnMap.X + ", " + ScaledMousePosOnMap.Y + ")", Font, new SolidBrush(ForeColor), 10, 100);
-		}
+            g.DrawString("Zoom x" + (int)RenderScale, Font, new SolidBrush(ForeColor), 10, 25);
+            g.DrawString("Camera (" + CameraPosition.X + ", " + CameraPosition.Y + ")", Font, new SolidBrush(ForeColor), 10, 40);
+            g.DrawString("Mouse (" + mousePos.X + ", " + mousePos.Y + ")", Font, new SolidBrush(ForeColor), 10, 55);
+            //g.DrawString("Map Size " + MapSize + "px", Font, new SolidBrush(ForeColor), 10, 70);
+            g.DrawString("Mouse Pos On Map (" + MousePosOnMap.X + ", " + MousePosOnMap.Y + ")", Font, new SolidBrush(ForeColor), 10, 85);
+            //g.DrawString("Scaled Mouse Pos On Map (" + ScaledMousePosOnMap.X + ", " + ScaledMousePosOnMap.Y + ")", Font, new SolidBrush(ForeColor), 10, 100);
+        }
 
-		protected override void OnPaintBackground(PaintEventArgs e)
-		{
-			Graphics g = e.Graphics;
-			g.FillRectangle(new SolidBrush(BackColor), ClientRectangle);
-		}
+        protected override void OnPaintBackground(PaintEventArgs e)
+        {
+            Graphics g = e.Graphics;
+            g.FillRectangle(new SolidBrush(BackColor), ClientRectangle);
+        }
 
-		protected override void OnResize(EventArgs e)
-		{
-			Invalidate();
-		}
+        protected override void OnResize(EventArgs e)
+        {
+            Invalidate();
+        }
 
-		private void OnPVSUpdated()
-		{
-			Refresh();
-			Invalidate();
-		}
-	}
+        private void OnPVSUpdated()
+        {
+            Refresh();
+            Invalidate();
+        }
+    }
 }

--- a/PVSFormat/PVSEditor.Designer.cs
+++ b/PVSFormat/PVSEditor.Designer.cs
@@ -28,73 +28,73 @@
         /// </summary>
         private void InitializeComponent()
         {
-			this.stsMain = new System.Windows.Forms.StatusStrip();
-			this.mnuMain = new System.Windows.Forms.MenuStrip();
-			this.debugToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.pvsMain = new PVSFormat.PVSEditControl();
-			this.mnuMain.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// stsMain
-			// 
-			this.stsMain.Location = new System.Drawing.Point(0, 339);
-			this.stsMain.Name = "stsMain";
-			this.stsMain.Size = new System.Drawing.Size(524, 22);
-			this.stsMain.TabIndex = 1;
-			this.stsMain.Text = "statusStrip1";
-			// 
-			// mnuMain
-			// 
-			this.mnuMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.stsMain = new System.Windows.Forms.StatusStrip();
+            this.mnuMain = new System.Windows.Forms.MenuStrip();
+            this.debugToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.pvsMain = new PVSFormat.PVSEditControl();
+            this.mnuMain.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // stsMain
+            // 
+            this.stsMain.Location = new System.Drawing.Point(0, 339);
+            this.stsMain.Name = "stsMain";
+            this.stsMain.Size = new System.Drawing.Size(524, 22);
+            this.stsMain.TabIndex = 1;
+            this.stsMain.Text = "statusStrip1";
+            // 
+            // mnuMain
+            // 
+            this.mnuMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.debugToolStripMenuItem});
-			this.mnuMain.Location = new System.Drawing.Point(0, 0);
-			this.mnuMain.Name = "mnuMain";
-			this.mnuMain.Size = new System.Drawing.Size(524, 24);
-			this.mnuMain.TabIndex = 2;
-			this.mnuMain.Text = "menuStrip1";
-			// 
-			// debugToolStripMenuItem
-			// 
-			this.debugToolStripMenuItem.Name = "debugToolStripMenuItem";
-			this.debugToolStripMenuItem.Size = new System.Drawing.Size(54, 20);
-			this.debugToolStripMenuItem.Text = "Debug";
-			this.debugToolStripMenuItem.Click += new System.EventHandler(this.DebugToolStripMenuItem_Click);
-			// 
-			// pvsMain
-			// 
-			this.pvsMain.BackColor = System.Drawing.Color.Black;
-			this.pvsMain.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.pvsMain.Font = new System.Drawing.Font("Courier New", 10F);
-			this.pvsMain.ForeColor = System.Drawing.Color.White;
-			this.pvsMain.Location = new System.Drawing.Point(0, 24);
-			this.pvsMain.Name = "pvsMain";
-			this.pvsMain.PVS = null;
-			this.pvsMain.Size = new System.Drawing.Size(524, 315);
-			this.pvsMain.TabIndex = 3;
-			this.pvsMain.Text = "pvsEditControl1";
-			// 
-			// PVSEditor
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(524, 361);
-			this.Controls.Add(this.pvsMain);
-			this.Controls.Add(this.stsMain);
-			this.Controls.Add(this.mnuMain);
-			this.MainMenuStrip = this.mnuMain;
-			this.Name = "PVSEditor";
-			this.Text = "PVSEditor";
-			this.mnuMain.ResumeLayout(false);
-			this.mnuMain.PerformLayout();
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.mnuMain.Location = new System.Drawing.Point(0, 0);
+            this.mnuMain.Name = "mnuMain";
+            this.mnuMain.Size = new System.Drawing.Size(524, 24);
+            this.mnuMain.TabIndex = 2;
+            this.mnuMain.Text = "menuStrip1";
+            // 
+            // debugToolStripMenuItem
+            // 
+            this.debugToolStripMenuItem.Name = "debugToolStripMenuItem";
+            this.debugToolStripMenuItem.Size = new System.Drawing.Size(54, 20);
+            this.debugToolStripMenuItem.Text = "Debug";
+            this.debugToolStripMenuItem.Click += new System.EventHandler(this.DebugToolStripMenuItem_Click);
+            // 
+            // pvsMain
+            // 
+            this.pvsMain.BackColor = System.Drawing.Color.Black;
+            this.pvsMain.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.pvsMain.Font = new System.Drawing.Font("Courier New", 10F);
+            this.pvsMain.ForeColor = System.Drawing.Color.White;
+            this.pvsMain.Location = new System.Drawing.Point(0, 24);
+            this.pvsMain.Name = "pvsMain";
+            this.pvsMain.PVS = null;
+            this.pvsMain.Size = new System.Drawing.Size(524, 315);
+            this.pvsMain.TabIndex = 3;
+            this.pvsMain.Text = "pvsEditControl1";
+            // 
+            // PVSEditor
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(524, 361);
+            this.Controls.Add(this.pvsMain);
+            this.Controls.Add(this.stsMain);
+            this.Controls.Add(this.mnuMain);
+            this.MainMenuStrip = this.mnuMain;
+            this.Name = "PVSEditor";
+            this.Text = "PVSEditor";
+            this.mnuMain.ResumeLayout(false);
+            this.mnuMain.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
         #endregion
         private System.Windows.Forms.StatusStrip stsMain;
-		private System.Windows.Forms.MenuStrip mnuMain;
-		private System.Windows.Forms.ToolStripMenuItem debugToolStripMenuItem;
-		private PVSEditControl pvsMain;
-	}
+        private System.Windows.Forms.MenuStrip mnuMain;
+        private System.Windows.Forms.ToolStripMenuItem debugToolStripMenuItem;
+        private PVSEditControl pvsMain;
+    }
 }

--- a/PVSFormat/PVSEditor.cs
+++ b/PVSFormat/PVSEditor.cs
@@ -10,11 +10,11 @@ namespace PVSFormat
     {
         private PVS _currentPVS;
 
-		public Image GameMap
-		{
-			get => pvsMain.GameMap;
-			set => pvsMain.GameMap = value;
-		}
+        public Image GameMap
+        {
+            get => pvsMain.GameMap;
+            set => pvsMain.GameMap = value;
+        }
 
         public PVSEditor()
         {
@@ -23,8 +23,8 @@ namespace PVSFormat
 
         public void UpdateDisplay()
         {
-			//dbgMain.SelectedObject = _currentPVS;
-			pvsMain.PVS = _currentPVS;
+            //dbgMain.SelectedObject = _currentPVS;
+            pvsMain.PVS = _currentPVS;
         }
 
         public void Open(PVS pvs)
@@ -34,9 +34,9 @@ namespace PVSFormat
             UpdateDisplay();
         }
 
-		private void DebugToolStripMenuItem_Click(object sender, System.EventArgs e)
-		{
-			DebugUtil.ShowDebug(_currentPVS);
-		}
-	}
+        private void DebugToolStripMenuItem_Click(object sender, System.EventArgs e)
+        {
+            DebugUtil.ShowDebug(_currentPVS);
+        }
+    }
 }

--- a/PVSFormat/PVSPlugin.cs
+++ b/PVSFormat/PVSPlugin.cs
@@ -8,21 +8,21 @@ using System.Threading.Tasks;
 
 namespace PVSFormat
 {
-	public class PVSPlugin : Plugin
-	{
-		public override void Init()
-		{
-			EntryTypeRegistry.Register(EntryType.ZoneList, new PVS());
-		}
+    public class PVSPlugin : Plugin
+    {
+        public override void Init()
+        {
+            EntryTypeRegistry.Register(EntryType.ZoneList, new PVS());
+        }
 
-		public override string GetID()
-		{
-			return "pvsplugin";
-		}
+        public override string GetID()
+        {
+            return "pvsplugin";
+        }
 
-		public override string GetName()
-		{
-			return "PVS Resource Handler";
-		}
-	}
+        public override string GetName()
+        {
+            return "PVS Resource Handler";
+        }
+    }
 }

--- a/PVSFormat/Polygon.cs
+++ b/PVSFormat/Polygon.cs
@@ -7,102 +7,102 @@ using System.Threading.Tasks;
 
 namespace PVSFormat
 {
-	public class Polygon
-	{
-		public PointF[] Points
-		{
-			get;
-			set;
-		}
+    public class Polygon
+    {
+        public PointF[] Points
+        {
+            get;
+            set;
+        }
 
-		public float MinX
-		{
-			get
-			{
-				float min = float.MaxValue;
+        public float MinX
+        {
+            get
+            {
+                float min = float.MaxValue;
 
-				foreach (PointF point in Points)
-				{
-					float current = point.X;
+                foreach (PointF point in Points)
+                {
+                    float current = point.X;
 
-					if (current < min)
-						min = current;
-				}
+                    if (current < min)
+                        min = current;
+                }
 
-				return min;
-			}
-		}
+                return min;
+            }
+        }
 
-		public float MinY
-		{
-			get
-			{
-				float min = float.MaxValue;
+        public float MinY
+        {
+            get
+            {
+                float min = float.MaxValue;
 
-				foreach (PointF point in Points)
-				{
-					float current = point.Y;
+                foreach (PointF point in Points)
+                {
+                    float current = point.Y;
 
-					if (current < min)
-						min = current;
-				}
+                    if (current < min)
+                        min = current;
+                }
 
-				return min;
-			}
-		}
+                return min;
+            }
+        }
 
-		public float MaxX
-		{
-			get
-			{
-				float max = float.MinValue;
+        public float MaxX
+        {
+            get
+            {
+                float max = float.MinValue;
 
-				foreach (PointF point in Points)
-				{
-					float current = point.X;
+                foreach (PointF point in Points)
+                {
+                    float current = point.X;
 
-					if (current > max)
-						max = current;
-				}
+                    if (current > max)
+                        max = current;
+                }
 
-				return max;
-			}
-		}
+                return max;
+            }
+        }
 
-		public float MaxY
-		{
-			get
-			{
-				float max = float.MinValue;
+        public float MaxY
+        {
+            get
+            {
+                float max = float.MinValue;
 
-				foreach (PointF point in Points)
-				{
-					float current = point.Y;
+                foreach (PointF point in Points)
+                {
+                    float current = point.Y;
 
-					if (current > max)
-						max = current;
-				}
+                    if (current > max)
+                        max = current;
+                }
 
-				return max;
-			}
-		}
+                return max;
+            }
+        }
 
-		public RectangleF Bounds
-		{
-			get
-			{
-				return new RectangleF(MinX, MinY, MaxX - MinX, MaxY - MinY);
-			}
-		}
+        public RectangleF Bounds
+        {
+            get
+            {
+                return new RectangleF(MinX, MinY, MaxX - MinX, MaxY - MinY);
+            }
+        }
 
-		public Polygon(params PointF[] points)
-		{
-			Points = points;
-		}
+        public Polygon(params PointF[] points)
+        {
+            Points = points;
+        }
 
-		public Polygon(List<PointF> points)
-		{
-			Points = points.ToArray();
-		}
-	}
+        public Polygon(List<PointF> points)
+        {
+            Points = points.ToArray();
+        }
+    }
 }

--- a/PluginAPI/EntryTypeRegistry.cs
+++ b/PluginAPI/EntryTypeRegistry.cs
@@ -7,38 +7,38 @@ using System.Threading.Tasks;
 
 namespace PluginAPI
 {
-	public static class EntryTypeRegistry
-	{
-		private static Dictionary<EntryType, IEntryData> _handlers = new Dictionary<EntryType, IEntryData>();
+    public static class EntryTypeRegistry
+    {
+        private static Dictionary<EntryType, IEntryData> _handlers = new Dictionary<EntryType, IEntryData>();
 
-		public static void Register(EntryType type, IEntryData handler)
-		{
-			if (IsRegistered(type))
-			{
-				Console.WriteLine("WARN: Handler for " + type.ToString() + " already registered!");
-				return;
-			}
-			_handlers.Add(type, handler);
-		}
+        public static void Register(EntryType type, IEntryData handler)
+        {
+            if (IsRegistered(type))
+            {
+                Console.WriteLine("WARN: Handler for " + type.ToString() + " already registered!");
+                return;
+            }
+            _handlers.Add(type, handler);
+        }
 
-		public static void Unregister(EntryType type)
-		{
-			if (!IsRegistered(type))
-				return;
-			_handlers.Remove(type);
-		}
+        public static void Unregister(EntryType type)
+        {
+            if (!IsRegistered(type))
+                return;
+            _handlers.Remove(type);
+        }
 
-		public static IEntryData GetHandler(EntryType type)
-		{
-			if (!IsRegistered(type))
-				return null;
+        public static IEntryData GetHandler(EntryType type)
+        {
+            if (!IsRegistered(type))
+                return null;
 
-			return _handlers[type];
-		}
+            return _handlers[type];
+        }
 
-		public static bool IsRegistered(EntryType type)
-		{
-			return _handlers.ContainsKey(type);
-		}
-	}
+        public static bool IsRegistered(EntryType type)
+        {
+            return _handlers.ContainsKey(type);
+        }
+    }
 }

--- a/PluginAPI/IEntryData.cs
+++ b/PluginAPI/IEntryData.cs
@@ -9,14 +9,14 @@ using System.Threading.Tasks;
 
 namespace PluginAPI
 {
-	public interface IEntryData
-	{
-		bool Read(BundleEntry entry, ILoader loader = null);
+    public interface IEntryData
+    {
+        bool Read(BundleEntry entry, ILoader loader = null);
 
-		bool Write(BundleEntry entry);
+        bool Write(BundleEntry entry);
 
-		EntryType GetEntryType(BundleEntry entry);
+        EntryType GetEntryType(BundleEntry entry);
 
-		IEntryEditor GetEditor(BundleEntry entry);
-	}
+        IEntryEditor GetEditor(BundleEntry entry);
+    }
 }

--- a/PluginAPI/IEntryEditor.cs
+++ b/PluginAPI/IEntryEditor.cs
@@ -7,8 +7,8 @@ using System.Windows.Forms;
 
 namespace PluginAPI
 {
-	public interface IEntryEditor
-	{
-		DialogResult ShowDialog(IWin32Window owner);
-	}
+    public interface IEntryEditor
+    {
+        DialogResult ShowDialog(IWin32Window owner);
+    }
 }

--- a/PluginAPI/Plugin.cs
+++ b/PluginAPI/Plugin.cs
@@ -8,18 +8,18 @@ namespace PluginAPI
 {
     public abstract class Plugin
     {
-		public virtual void Init()
-		{
-			// Stub
-		}
+        public virtual void Init()
+        {
+            // Stub
+        }
 
-		public abstract string GetID();
+        public abstract string GetID();
 
-		public abstract string GetName();
+        public abstract string GetName();
 
-		public virtual string GetDescription()
-		{
-			return null;
-		}
+        public virtual string GetDescription()
+        {
+            return null;
+        }
     }
 }

--- a/PluginAPI/PluginCommand.cs
+++ b/PluginAPI/PluginCommand.cs
@@ -8,22 +8,22 @@ using System.Windows.Forms;
 
 namespace PluginAPI
 {
-	public struct PluginCommand
-	{
-		public delegate void OnUse(IWin32Window window, BundleArchive archive);
-		public delegate bool OnCheckConditions(BundleArchive archive);
+    public struct PluginCommand
+    {
+        public delegate void OnUse(IWin32Window window, BundleArchive archive);
+        public delegate bool OnCheckConditions(BundleArchive archive);
 
-		public string ID;
-		public string Text;
-		public OnUse Use;
-		public OnCheckConditions CheckConditions;
+        public string ID;
+        public string Text;
+        public OnUse Use;
+        public OnCheckConditions CheckConditions;
 
-		public PluginCommand(string id, string text, OnUse use, OnCheckConditions checkConditions = null)
-		{
-			ID = id;
-			Text = text;
-			CheckConditions = checkConditions;
-			Use = use;
-		}
-	}
+        public PluginCommand(string id, string text, OnUse use, OnCheckConditions checkConditions = null)
+        {
+            ID = id;
+            Text = text;
+            CheckConditions = checkConditions;
+            Use = use;
+        }
+    }
 }

--- a/PluginAPI/PluginCommandRegistry.cs
+++ b/PluginAPI/PluginCommandRegistry.cs
@@ -6,47 +6,47 @@ using System.Threading.Tasks;
 
 namespace PluginAPI
 {
-	public static class PluginCommandRegistry
-	{
-		private static Dictionary<string, PluginCommand> _commands = new Dictionary<string, PluginCommand>();
+    public static class PluginCommandRegistry
+    {
+        private static Dictionary<string, PluginCommand> _commands = new Dictionary<string, PluginCommand>();
 
-		public static PluginCommand[] Commands => _commands.Values.ToArray();
+        public static PluginCommand[] Commands => _commands.Values.ToArray();
 
-		public static void Register(string id, string text, PluginCommand.OnUse use, PluginCommand.OnCheckConditions checkConditions = null)
-		{
-			Register(new PluginCommand(id, text, use, checkConditions));
-		}
+        public static void Register(string id, string text, PluginCommand.OnUse use, PluginCommand.OnCheckConditions checkConditions = null)
+        {
+            Register(new PluginCommand(id, text, use, checkConditions));
+        }
 
-		public static void Register(PluginCommand command)
-		{
-			if (IsRegistered(command.ID))
-			{
-				Console.WriteLine("WARN: Command " + command.ID.ToString() + " already registered!");
-				return;
-			}
+        public static void Register(PluginCommand command)
+        {
+            if (IsRegistered(command.ID))
+            {
+                Console.WriteLine("WARN: Command " + command.ID.ToString() + " already registered!");
+                return;
+            }
 
-			_commands.Add(command.ID, command);
-		}
+            _commands.Add(command.ID, command);
+        }
 
-		public static void Unregister(string id)
-		{
-			if (!IsRegistered(id))
-				return;
+        public static void Unregister(string id)
+        {
+            if (!IsRegistered(id))
+                return;
 
-			_commands.Remove(id);
-		}
+            _commands.Remove(id);
+        }
 
-		public static PluginCommand GetCommand(string id)
-		{
-			if (!IsRegistered(id))
-				return default;
+        public static PluginCommand GetCommand(string id)
+        {
+            if (!IsRegistered(id))
+                return default;
 
-			return _commands[id];
-		}
+            return _commands[id];
+        }
 
-		public static bool IsRegistered(string id)
-		{
-			return _commands.ContainsKey(id);
-		}
-	}
+        public static bool IsRegistered(string id)
+        {
+            return _commands.ContainsKey(id);
+        }
+    }
 }

--- a/PluginSystem/PluginLoader.cs
+++ b/PluginSystem/PluginLoader.cs
@@ -13,109 +13,109 @@ namespace PluginSystem
 {
     public static class PluginLoader
     {
-		private static readonly Dictionary<string, Plugin> _plugins = new Dictionary<string, Plugin>();
+        private static readonly Dictionary<string, Plugin> _plugins = new Dictionary<string, Plugin>();
 
-		private delegate void OnLog(string message);
-		private static event OnLog Log;
+        private delegate void OnLog(string message);
+        private static event OnLog Log;
 
-		private static void LogInfo(string message)
-		{
-			if (Log == null)
-			{
-				Console.WriteLine(message);
-				//Debug.WriteLine(message);
-			}
+        private static void LogInfo(string message)
+        {
+            if (Log == null)
+            {
+                Console.WriteLine(message);
+                //Debug.WriteLine(message);
+            }
 
-			Log?.Invoke(message);
-		}
+            Log?.Invoke(message);
+        }
 
-		private static void ScanPluginsFolder()
-		{
-			LogInfo("Scanning Plugins Folder");
+        private static void ScanPluginsFolder()
+        {
+            LogInfo("Scanning Plugins Folder");
 
-			string directory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "plugins");
-			Directory.CreateDirectory(directory);
-			string[] pluginDLLs = Directory.GetFiles(directory, "*.dll", SearchOption.TopDirectoryOnly);
+            string directory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "plugins");
+            Directory.CreateDirectory(directory);
+            string[] pluginDLLs = Directory.GetFiles(directory, "*.dll", SearchOption.TopDirectoryOnly);
 
-			foreach (string pluginDLL in pluginDLLs)
-			{
-				try
-				{
-					Assembly.LoadFile(pluginDLL);
-				}
-				catch (Exception ex)
-				{
-					LogInfo(ex.Message + "\n" + ex.StackTrace);
-				}
-			}
-		}
+            foreach (string pluginDLL in pluginDLLs)
+            {
+                try
+                {
+                    Assembly.LoadFile(pluginDLL);
+                }
+                catch (Exception ex)
+                {
+                    LogInfo(ex.Message + "\n" + ex.StackTrace);
+                }
+            }
+        }
 
-		private static void FindPlugins()
-		{
-			LogInfo("Finding Plugins");
+        private static void FindPlugins()
+        {
+            LogInfo("Finding Plugins");
 
-			Type pluginType = typeof(Plugin);
+            Type pluginType = typeof(Plugin);
 
-			List<Assembly> assemblies = AssemblyUtil.BuildAssemblyList();
+            List<Assembly> assemblies = AssemblyUtil.BuildAssemblyList();
 
-			foreach (Assembly assembly in assemblies)
-			{
-				//LogInfo("Scanning Assembly: " + assembly.GetName().Name);
+            foreach (Assembly assembly in assemblies)
+            {
+                //LogInfo("Scanning Assembly: " + assembly.GetName().Name);
 
-				foreach (Type type in assembly.GetTypes())
-				{
-					if (!type.IsSubclassOf(pluginType))
-						continue;
+                foreach (Type type in assembly.GetTypes())
+                {
+                    if (!type.IsSubclassOf(pluginType))
+                        continue;
 
-					try
-					{
-						Plugin plugin = Activator.CreateInstance(type, true) as Plugin;
-						if (plugin == null)
-						{
-							throw new InvalidCastException("Type is not plugin");
-						}
+                    try
+                    {
+                        Plugin plugin = Activator.CreateInstance(type, true) as Plugin;
+                        if (plugin == null)
+                        {
+                            throw new InvalidCastException("Type is not plugin");
+                        }
 
-						if (plugin.GetID() == null)
-						{
-							LogInfo(type.FullName + " is missing Plugin ID!");
-							continue;
-						}
+                        if (plugin.GetID() == null)
+                        {
+                            LogInfo(type.FullName + " is missing Plugin ID!");
+                            continue;
+                        }
 
-						if (_plugins.ContainsKey(plugin.GetID()))
-							continue;
-						_plugins.Add(plugin.GetID(), plugin);
+                        if (_plugins.ContainsKey(plugin.GetID()))
+                            continue;
+                        _plugins.Add(plugin.GetID(), plugin);
 
-					} catch (Exception ex)
-					{
-						string err = ex.Message + "\n" + ex.StackTrace;
-						LogInfo(err);
-						continue;
-					}
-				}
-			}
-		}
+                    } catch (Exception ex)
+                    {
+                        string err = ex.Message + "\n" + ex.StackTrace;
+                        LogInfo(err);
+                        continue;
+                    }
+                }
+            }
+        }
 
-		private static void InitPlugin(Plugin plugin)
-		{
-			LogInfo("Initializing Plugin (" + plugin.GetID() + ":" + plugin.GetName() + ")");
-			plugin.Init();
-		}
+        private static void InitPlugin(Plugin plugin)
+        {
+            LogInfo("Initializing Plugin (" + plugin.GetID() + ":" + plugin.GetName() + ")");
+            plugin.Init();
+        }
 
-		private static void InitPlugins()
-		{
-			LogInfo("Initializing Plugins");
-			foreach (var plugin in _plugins)
-			{
-				InitPlugin(plugin.Value);
-			}
-		}
+        private static void InitPlugins()
+        {
+            LogInfo("Initializing Plugins");
+            foreach (var plugin in _plugins)
+            {
+                InitPlugin(plugin.Value);
+            }
+        }
 
-		public static void LoadPlugins()
-		{
-			LogInfo("Loading Plugins");
-			ScanPluginsFolder();
-			FindPlugins();
-			InitPlugins();
-		}
+        public static void LoadPlugins()
+        {
+            LogInfo("Loading Plugins");
+            ScanPluginsFolder();
+            FindPlugins();
+            InitPlugins();
+        }
     }
 }

--- a/PluginSystem/Util/AssemblyUtil.cs
+++ b/PluginSystem/Util/AssemblyUtil.cs
@@ -7,47 +7,47 @@ using System.Threading.Tasks;
 
 namespace PluginSystem.Util
 {
-	public static class AssemblyUtil
-	{
-		private static bool ContainsAssembly(this List<Assembly> self, string fullname)
-		{
-			foreach (Assembly assembly in self)
-			{
-				if (assembly.FullName == fullname)
-					return true;
-			}
+    public static class AssemblyUtil
+    {
+        private static bool ContainsAssembly(this List<Assembly> self, string fullname)
+        {
+            foreach (Assembly assembly in self)
+            {
+                if (assembly.FullName == fullname)
+                    return true;
+            }
 
-			return false;
-		}
+            return false;
+        }
 
-		private static void AddAssemblyWithReferences(this List<Assembly> self, Assembly assembly)
-		{
-			if (!self.Contains(assembly))
-				self.Add(assembly);
+        private static void AddAssemblyWithReferences(this List<Assembly> self, Assembly assembly)
+        {
+            if (!self.Contains(assembly))
+                self.Add(assembly);
 
-			AssemblyName[] references = assembly.GetReferencedAssemblies();
-			foreach (AssemblyName reference in references)
-			{
-				if (self.ContainsAssembly(reference.FullName))
-					continue;
+            AssemblyName[] references = assembly.GetReferencedAssemblies();
+            foreach (AssemblyName reference in references)
+            {
+                if (self.ContainsAssembly(reference.FullName))
+                    continue;
 
-				try
-				{
-					self.AddAssemblyWithReferences(Assembly.Load(reference));
-				}
-				catch { }
-			}
-		}
+                try
+                {
+                    self.AddAssemblyWithReferences(Assembly.Load(reference));
+                }
+                catch { }
+            }
+        }
 
-		internal static List<Assembly> BuildAssemblyList()
-		{
-			List<Assembly> assemblies = new List<Assembly>();
-			foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
-			{
-				AddAssemblyWithReferences(assemblies, assembly);
-			}
+        internal static List<Assembly> BuildAssemblyList()
+        {
+            List<Assembly> assemblies = new List<Assembly>();
+            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                AddAssemblyWithReferences(assemblies, assembly);
+            }
 
-			return assemblies;
-		}
-	}
+            return assemblies;
+        }
+    }
 }

--- a/VaultFormat/AttribSys.cs
+++ b/VaultFormat/AttribSys.cs
@@ -301,28 +301,28 @@ namespace VaultFormat
             }
         }
 
-		private void Clear()
-		{
-			VersionHash = default;
-			DepHash1 = default;
-			DepHash2 = default;
-			DepNop = default;
+        private void Clear()
+        {
+            VersionHash = default;
+            DepHash1 = default;
+            DepHash2 = default;
+            DepNop = default;
 
-			StrUnknown1 = default;
+            StrUnknown1 = default;
 
-			PtrN = default;
+            PtrN = default;
 
-			Data = default;
+            Data = default;
 
-			Dependencies.Clear();
-			NestedChunks.Clear();
-			DataChunks.Clear();
-			Strings.Clear();
-		}
+            Dependencies.Clear();
+            NestedChunks.Clear();
+            DataChunks.Clear();
+            Strings.Clear();
+        }
 
         public bool Read(BundleEntry entry, ILoader loader = null)
         {
-			Clear();
+            Clear();
 
             MemoryStream ms = entry.MakeStream();
             BinaryReader2 br = new BinaryReader2(ms);
@@ -359,19 +359,19 @@ namespace VaultFormat
             return true;
         }
 
-		public bool Write(BundleEntry entry)
-		{
-			return true;
-		}
+        public bool Write(BundleEntry entry)
+        {
+            return true;
+        }
 
-		public EntryType GetEntryType(BundleEntry entry)
-		{
-			return EntryType.AttribSysVault;
-		}
+        public EntryType GetEntryType(BundleEntry entry)
+        {
+            return EntryType.AttribSysVault;
+        }
 
-		public IEntryEditor GetEditor(BundleEntry entry)
-		{
-			return null;
-		}
-	}
+        public IEntryEditor GetEditor(BundleEntry entry)
+        {
+            return null;
+        }
+    }
 }

--- a/VaultFormat/AttribSysPlugin.cs
+++ b/VaultFormat/AttribSysPlugin.cs
@@ -8,21 +8,21 @@ using System.Threading.Tasks;
 
 namespace VaultFormat
 {
-	public class AttribSysPlugin : Plugin
-	{
-		public override void Init()
-		{
-			EntryTypeRegistry.Register(EntryType.AttribSysVault, new AttribSys());
-		}
+    public class AttribSysPlugin : Plugin
+    {
+        public override void Init()
+        {
+            EntryTypeRegistry.Register(EntryType.AttribSysVault, new AttribSys());
+        }
 
-		public override string GetID()
-		{
-			return "attribsysplugin";
-		}
+        public override string GetID()
+        {
+            return "attribsysplugin";
+        }
 
-		public override string GetName()
-		{
-			return "AttribSys Resource Handler";
-		}
-	}
+        public override string GetName()
+        {
+            return "AttribSys Resource Handler";
+        }
+    }
 }

--- a/VehicleList/VehicleListData.cs
+++ b/VehicleList/VehicleListData.cs
@@ -126,7 +126,7 @@ namespace VehicleList
     }
 
     public class VehicleListData : IEntryData
-	{
+    {
         public int Unknown1;
         public int Unknown2;
         public List<Vehicle> Entries;
@@ -136,171 +136,171 @@ namespace VehicleList
             Entries = new List<Vehicle>();
         }
 
-		public IEntryEditor GetEditor(BundleEntry entry)
-		{
-			VehicleListForm vehicleList = new VehicleListForm();
-			vehicleList.List = this;
-			vehicleList.Edit += () =>
-			{
-				Write(entry);
-			};
+        public IEntryEditor GetEditor(BundleEntry entry)
+        {
+            VehicleListForm vehicleList = new VehicleListForm();
+            vehicleList.List = this;
+            vehicleList.Edit += () =>
+            {
+                Write(entry);
+            };
 
-			return vehicleList;
-		}
+            return vehicleList;
+        }
 
-		public EntryType GetEntryType(BundleEntry entry)
-		{
-			return EntryType.VehicleList;
-		}
+        public EntryType GetEntryType(BundleEntry entry)
+        {
+            return EntryType.VehicleList;
+        }
 
-		private void Clear()
-		{
-			Unknown1 = default;
-			Unknown2 = default;
-			Entries.Clear();
-		}
+        private void Clear()
+        {
+            Unknown1 = default;
+            Unknown2 = default;
+            Entries.Clear();
+        }
 
-		public bool Read(BundleEntry entry, ILoader loader = null)
-		{
-			Clear();
+        public bool Read(BundleEntry entry, ILoader loader = null)
+        {
+            Clear();
 
-			MemoryStream ms = new MemoryStream(entry.EntryBlocks[0].Data);
-			BinaryReader2 br = new BinaryReader2(ms);
-			br.BigEndian = entry.Console;
+            MemoryStream ms = new MemoryStream(entry.EntryBlocks[0].Data);
+            BinaryReader2 br = new BinaryReader2(ms);
+            br.BigEndian = entry.Console;
 
-			int count = br.ReadInt32();
-			int startOff = br.ReadInt32();
+            int count = br.ReadInt32();
+            int startOff = br.ReadInt32();
 
-			Unknown1 = br.ReadInt32();
-			Unknown2 = br.ReadInt32();
+            Unknown1 = br.ReadInt32();
+            Unknown2 = br.ReadInt32();
 
-			for (int i = 0; i < count; i++)
-			{
-				Vehicle vehicle = new Vehicle();
+            for (int i = 0; i < count; i++)
+            {
+                Vehicle vehicle = new Vehicle();
 
-				vehicle.Index = i;
+                vehicle.Index = i;
 
-				vehicle.ID = br.ReadEncryptedString();
-				vehicle.ParentID = br.ReadEncryptedString();
-				vehicle.WheelType = Encoding.ASCII.GetString(br.ReadBytes(32));
-				vehicle.CarName = Encoding.ASCII.GetString(br.ReadBytes(64));
-				vehicle.CarBrand = Encoding.ASCII.GetString(br.ReadBytes(32));
-				vehicle.DamageLimit = br.ReadSingle();
-				vehicle.Flags = (Flags)br.ReadInt32();
-				vehicle.BoostLength = br.ReadByte();
+                vehicle.ID = br.ReadEncryptedString();
+                vehicle.ParentID = br.ReadEncryptedString();
+                vehicle.WheelType = Encoding.ASCII.GetString(br.ReadBytes(32));
+                vehicle.CarName = Encoding.ASCII.GetString(br.ReadBytes(64));
+                vehicle.CarBrand = Encoding.ASCII.GetString(br.ReadBytes(32));
+                vehicle.DamageLimit = br.ReadSingle();
+                vehicle.Flags = (Flags)br.ReadInt32();
+                vehicle.BoostLength = br.ReadByte();
                 vehicle.VehicleRank = (VehicleRank)br.ReadByte();
-				vehicle.BoostCapacity = br.ReadByte();
-				vehicle.DisplayStrength = br.ReadByte();
-				vehicle.padding0 = br.ReadInt32();
-				vehicle.AttribSysCollectionKey = br.ReadInt64();
-				vehicle.ExhaustName = br.ReadEncryptedString();
-				vehicle.ExhaustID = br.ReadInt64();
-				vehicle.EngineID = br.ReadInt64();
-				vehicle.EngineName = br.ReadEncryptedString();
-				vehicle.ClassUnlockStreamHash = (ClassUnlock)br.ReadInt32();
-				vehicle.padding1 = br.ReadInt32();
-				vehicle.CarShutdownStreamID = br.ReadInt64();
-				vehicle.CarReleasedStreamID = br.ReadInt64();
-				vehicle.AIMusicHash = (AIMusic)br.ReadInt32();
-				vehicle.AIExhaustIndex = (AIExhaustIndex)br.ReadByte();
-				vehicle.AIExhaustIndex2 = (AIExhaustIndex)br.ReadByte();
-				vehicle.AIExhaustIndex3 = (AIExhaustIndex)br.ReadByte();
-				vehicle.padding2 = br.ReadByte();
-				vehicle.Unknown[0] = br.ReadInt64();
+                vehicle.BoostCapacity = br.ReadByte();
+                vehicle.DisplayStrength = br.ReadByte();
+                vehicle.padding0 = br.ReadInt32();
+                vehicle.AttribSysCollectionKey = br.ReadInt64();
+                vehicle.ExhaustName = br.ReadEncryptedString();
+                vehicle.ExhaustID = br.ReadInt64();
+                vehicle.EngineID = br.ReadInt64();
+                vehicle.EngineName = br.ReadEncryptedString();
+                vehicle.ClassUnlockStreamHash = (ClassUnlock)br.ReadInt32();
+                vehicle.padding1 = br.ReadInt32();
+                vehicle.CarShutdownStreamID = br.ReadInt64();
+                vehicle.CarReleasedStreamID = br.ReadInt64();
+                vehicle.AIMusicHash = (AIMusic)br.ReadInt32();
+                vehicle.AIExhaustIndex = (AIExhaustIndex)br.ReadByte();
+                vehicle.AIExhaustIndex2 = (AIExhaustIndex)br.ReadByte();
+                vehicle.AIExhaustIndex3 = (AIExhaustIndex)br.ReadByte();
+                vehicle.padding2 = br.ReadByte();
+                vehicle.Unknown[0] = br.ReadInt64();
                 vehicle.Unknown[1] = br.ReadInt64();
                 vehicle.Category = (VehicleCategory)br.ReadInt32();
                 vehicle.VehicleAndBoostType = br.ReadByte();
-				vehicle.FinishType = (FinishType)br.ReadByte();
-				vehicle.MaxSpeedNoBoost = br.ReadByte();
-				vehicle.MaxSpeedBoost = br.ReadByte();
-				vehicle.DisplaySpeed = br.ReadByte();
-				vehicle.DisplayBoost = br.ReadByte();
+                vehicle.FinishType = (FinishType)br.ReadByte();
+                vehicle.MaxSpeedNoBoost = br.ReadByte();
+                vehicle.MaxSpeedBoost = br.ReadByte();
+                vehicle.DisplaySpeed = br.ReadByte();
+                vehicle.DisplayBoost = br.ReadByte();
                 vehicle.Color = br.ReadByte();
                 vehicle.ColorType = (ColorType)br.ReadByte();
-				vehicle.padding3 = br.ReadInt32();
+                vehicle.padding3 = br.ReadInt32();
 
                 vehicle.VehicleType = (VehicleType)(vehicle.VehicleAndBoostType >> 4 & 0xF); // High nibble
                 vehicle.BoostType = (BoostType)(vehicle.VehicleAndBoostType & 0xF); // Low nibble
 
                 Entries.Add(vehicle);
-			}
+            }
 
-			br.Close();
-			return true;
-		}
+            br.Close();
+            return true;
+        }
 
-		public bool Write(BundleEntry entry)
-		{
-			MemoryStream ms = new MemoryStream();
-			BinaryWriter bw = new BinaryWriter(ms);
+        public bool Write(BundleEntry entry)
+        {
+            MemoryStream ms = new MemoryStream();
+            BinaryWriter bw = new BinaryWriter(ms);
 
-			bool console = entry.Console;
-			// TODO: Implement Console Saving
+            bool console = entry.Console;
+            // TODO: Implement Console Saving
 
-			bw.Write(console ? Util.ReverseBytes((int)Entries.Count) : (int)Entries.Count);
-			bw.Write(console ? Util.ReverseBytes((int)0x10) : (int)0x10);
+            bw.Write(console ? Util.ReverseBytes((int)Entries.Count) : (int)Entries.Count);
+            bw.Write(console ? Util.ReverseBytes((int)0x10) : (int)0x10);
 
-			bw.Write(console ? Util.ReverseBytes(Unknown1) : Unknown1);
-			bw.Write(console ? Util.ReverseBytes(Unknown2) : Unknown2);
+            bw.Write(console ? Util.ReverseBytes(Unknown1) : Unknown1);
+            bw.Write(console ? Util.ReverseBytes(Unknown2) : Unknown2);
 
-			for (int i = 0; i < Entries.Count; i++)
-			{
-				Vehicle vehicle = Entries[i];
+            for (int i = 0; i < Entries.Count; i++)
+            {
+                Vehicle vehicle = Entries[i];
 
                 // Need to create the correct byte before writing
                 vehicle.VehicleAndBoostType = (byte)(((byte)vehicle.VehicleType << 4) + (byte)vehicle.BoostType);
 
-				bw.WriteEncryptedString(vehicle.ID, console);
-				bw.WriteEncryptedString(vehicle.ParentID, console);
-				bw.WriteLenString(vehicle.WheelType, 32, console);
-				bw.WriteLenString(vehicle.CarName, 64, console);
-				bw.WriteLenString(vehicle.CarBrand, 32, console);
-				bw.Write(console ? Util.ReverseBytes(vehicle.DamageLimit) : vehicle.DamageLimit);
-				bw.Write(console ? Util.ReverseBytes((uint)vehicle.Flags) : (uint)vehicle.Flags);
-				bw.Write(vehicle.BoostLength);
+                bw.WriteEncryptedString(vehicle.ID, console);
+                bw.WriteEncryptedString(vehicle.ParentID, console);
+                bw.WriteLenString(vehicle.WheelType, 32, console);
+                bw.WriteLenString(vehicle.CarName, 64, console);
+                bw.WriteLenString(vehicle.CarBrand, 32, console);
+                bw.Write(console ? Util.ReverseBytes(vehicle.DamageLimit) : vehicle.DamageLimit);
+                bw.Write(console ? Util.ReverseBytes((uint)vehicle.Flags) : (uint)vehicle.Flags);
+                bw.Write(vehicle.BoostLength);
                 bw.Write((byte)vehicle.VehicleRank);
-				bw.Write(vehicle.BoostCapacity);
-				bw.Write(vehicle.DisplayStrength);
-				bw.Write(vehicle.padding0);
-				bw.Write(console ? Util.ReverseBytes(vehicle.AttribSysCollectionKey) : vehicle.AttribSysCollectionKey);
-				bw.WriteEncryptedString(vehicle.ExhaustName, console);
-				bw.Write(console ? Util.ReverseBytes(vehicle.ExhaustID) : vehicle.ExhaustID);
-				bw.Write(console ? Util.ReverseBytes(vehicle.EngineID) : vehicle.EngineID);
-				bw.WriteEncryptedString(vehicle.EngineName, console);
-				bw.Write(console ? Util.ReverseBytes((uint)vehicle.ClassUnlockStreamHash) : (uint)vehicle.ClassUnlockStreamHash);
-				bw.Write(vehicle.padding1);
-				bw.Write(console ? Util.ReverseBytes(vehicle.CarShutdownStreamID) : vehicle.CarShutdownStreamID);
-				bw.Write(console ? Util.ReverseBytes(vehicle.CarReleasedStreamID) : vehicle.CarReleasedStreamID);
-				bw.Write(console ? Util.ReverseBytes((uint)vehicle.AIMusicHash) : (uint)vehicle.AIMusicHash);
-				bw.Write((byte)vehicle.AIExhaustIndex);
-				bw.Write((byte)vehicle.AIExhaustIndex2);
-				bw.Write((byte)vehicle.AIExhaustIndex3);
-				bw.Write(vehicle.padding2);
-				bw.Write(vehicle.Unknown[0]);
+                bw.Write(vehicle.BoostCapacity);
+                bw.Write(vehicle.DisplayStrength);
+                bw.Write(vehicle.padding0);
+                bw.Write(console ? Util.ReverseBytes(vehicle.AttribSysCollectionKey) : vehicle.AttribSysCollectionKey);
+                bw.WriteEncryptedString(vehicle.ExhaustName, console);
+                bw.Write(console ? Util.ReverseBytes(vehicle.ExhaustID) : vehicle.ExhaustID);
+                bw.Write(console ? Util.ReverseBytes(vehicle.EngineID) : vehicle.EngineID);
+                bw.WriteEncryptedString(vehicle.EngineName, console);
+                bw.Write(console ? Util.ReverseBytes((uint)vehicle.ClassUnlockStreamHash) : (uint)vehicle.ClassUnlockStreamHash);
+                bw.Write(vehicle.padding1);
+                bw.Write(console ? Util.ReverseBytes(vehicle.CarShutdownStreamID) : vehicle.CarShutdownStreamID);
+                bw.Write(console ? Util.ReverseBytes(vehicle.CarReleasedStreamID) : vehicle.CarReleasedStreamID);
+                bw.Write(console ? Util.ReverseBytes((uint)vehicle.AIMusicHash) : (uint)vehicle.AIMusicHash);
+                bw.Write((byte)vehicle.AIExhaustIndex);
+                bw.Write((byte)vehicle.AIExhaustIndex2);
+                bw.Write((byte)vehicle.AIExhaustIndex3);
+                bw.Write(vehicle.padding2);
+                bw.Write(vehicle.Unknown[0]);
                 bw.Write(vehicle.Unknown[1]);
                 bw.Write(console ? Util.ReverseBytes((uint)vehicle.Category) : (uint)vehicle.Category);
-				bw.Write(vehicle.VehicleAndBoostType);
-				bw.Write((byte)vehicle.FinishType);
-				bw.Write(vehicle.MaxSpeedNoBoost);
-				bw.Write(vehicle.MaxSpeedBoost);
-				bw.Write(vehicle.DisplaySpeed);
-				bw.Write(vehicle.DisplayBoost);
+                bw.Write(vehicle.VehicleAndBoostType);
+                bw.Write((byte)vehicle.FinishType);
+                bw.Write(vehicle.MaxSpeedNoBoost);
+                bw.Write(vehicle.MaxSpeedBoost);
+                bw.Write(vehicle.DisplaySpeed);
+                bw.Write(vehicle.DisplayBoost);
                 bw.Write(vehicle.Color);
                 bw.Write((byte)vehicle.ColorType);
-				bw.Write(vehicle.padding3);
-			}
+                bw.Write(vehicle.padding3);
+            }
 
-			bw.Flush();
-			byte[] data = ms.ToArray();
-			bw.Close();
-			ms.Close();
+            bw.Flush();
+            byte[] data = ms.ToArray();
+            bw.Close();
+            ms.Close();
 
-			entry.EntryBlocks[0].Data = data;
-			entry.Dirty = true;
+            entry.EntryBlocks[0].Data = data;
+            entry.Dirty = true;
 
-			return true;
-		}
-	}
+            return true;
+        }
+    }
 
     public class Vehicle
     {

--- a/VehicleList/VehicleListForm.cs
+++ b/VehicleList/VehicleListForm.cs
@@ -22,16 +22,16 @@ namespace VehicleList
         public delegate void OnEdit();
         public event OnEdit Edit;
 
-		private VehicleListData _list;
+        private VehicleListData _list;
         public VehicleListData List
-		{
-			get => _list;
-			set
-			{
-				_list = value;
-				UpdateDisplay();
-			}
-		}
+        {
+            get => _list;
+            set
+            {
+                _list = value;
+                UpdateDisplay();
+            }
+        }
 
         public VehicleListForm()
         {

--- a/VehicleList/VehicleListPlugin.cs
+++ b/VehicleList/VehicleListPlugin.cs
@@ -8,21 +8,21 @@ using System.Threading.Tasks;
 
 namespace VehicleList
 {
-	public class VehicleListPlugin : Plugin
-	{
-		public override void Init()
-		{
-			EntryTypeRegistry.Register(EntryType.VehicleList, new VehicleListData());
-		}
+    public class VehicleListPlugin : Plugin
+    {
+        public override void Init()
+        {
+            EntryTypeRegistry.Register(EntryType.VehicleList, new VehicleListData());
+        }
 
-		public override string GetID()
-		{
-			return "vehiclelistplugin";
-		}
+        public override string GetID()
+        {
+            return "vehiclelistplugin";
+        }
 
-		public override string GetName()
-		{
-			return "VehicleList Resource Handler";
-		}
-	}
+        public override string GetName()
+        {
+            return "VehicleList Resource Handler";
+        }
+    }
 }

--- a/WorldCollisionHandler/PolygonSoupList.cs
+++ b/WorldCollisionHandler/PolygonSoupList.cs
@@ -23,12 +23,12 @@ namespace WorldCollisionHandler
     {
         public uint UnknownProperty;
         public byte[] Indices;
-		public byte[] UnknownBytes;
+        public byte[] UnknownBytes;
 
-		public PolygonSoupProperty()
+        public PolygonSoupProperty()
         {
             Indices = new byte[4];
-			UnknownBytes = new byte[4];
+            UnknownBytes = new byte[4];
         }
 
         public PolygonSoupProperty Copy()
@@ -57,12 +57,12 @@ namespace WorldCollisionHandler
             for (int i = 0; i < result.Indices.Length; i++)
             {
                 result.Indices[i] = br.ReadByte();
-			}
+            }
 
-			for (int i = 0; i < result.UnknownBytes.Length; i++)
-			{
-				result.UnknownBytes[i] = br.ReadByte();
-			}
+            for (int i = 0; i < result.UnknownBytes.Length; i++)
+            {
+                result.UnknownBytes[i] = br.ReadByte();
+            }
 
             return result;
         }
@@ -114,11 +114,11 @@ namespace WorldCollisionHandler
         public BoxF Box;
         public int Terminator;
 
-		public PolygonSoupBoundingBox(BoxF box, int terminator)
-		{
-			Box = box;
-			Terminator = terminator;
-		}
+        public PolygonSoupBoundingBox(BoxF box, int terminator)
+        {
+            Box = box;
+            Terminator = terminator;
+        }
 
         public override string ToString()
         {
@@ -175,15 +175,15 @@ namespace WorldCollisionHandler
         }
 
         public void Write(BinaryWriter bw)
-		{
-			long chunkStartPtr = bw.BaseStream.Position;
-			bw.Write(Position);
+        {
+            long chunkStartPtr = bw.BaseStream.Position;
+            bw.Write(Position);
             bw.Write(Scale);
             long propListStartPtr = bw.BaseStream.Position;
             bw.Write((uint) 0);
             long pointListStartPtr = bw.BaseStream.Position;
             bw.Write((uint) 0);
-			long lengthPtr = bw.BaseStream.Position;
+            long lengthPtr = bw.BaseStream.Position;
             bw.Write((ushort) 0);
             bw.Write((byte)PropertyList.Count);
             bw.Write(QuadCount);
@@ -211,12 +211,12 @@ namespace WorldCollisionHandler
             {
                 PropertyList[i].Write(bw);
             }
-			cPos = bw.BaseStream.Position;
-			bw.BaseStream.Position = lengthPtr;
-			bw.Write((short)(bw.BaseStream.Length - chunkStartPtr));
-			bw.BaseStream.Position = cPos;
+            cPos = bw.BaseStream.Position;
+            bw.BaseStream.Position = lengthPtr;
+            bw.Write((short)(bw.BaseStream.Length - chunkStartPtr));
+            bw.BaseStream.Position = cPos;
 
-		}
+        }
 
         public Mesh BuildMesh(Vector3I pos, float scale)
         {
@@ -390,7 +390,7 @@ namespace WorldCollisionHandler
 
             // Clear existing data
             Chunks.Clear();
-			BoundingBoxes.Clear();
+            BoundingBoxes.Clear();
 
             // Global vertices list to calculate the bounding box
             List<Vector3> vertices = new List<Vector3>();
@@ -489,236 +489,236 @@ namespace WorldCollisionHandler
             Max = MathUtils.MaxBounds(vertices.ToArray());
         }
 
-		private void Clear()
-		{
-			Min = default;
-			Unknown4 = default;
-			Max = default;
-			Unknown8 = default;
-			BoundingBoxes.Clear();
-			Chunks.Clear();
-		}
+        private void Clear()
+        {
+            Min = default;
+            Unknown4 = default;
+            Max = default;
+            Unknown8 = default;
+            BoundingBoxes.Clear();
+            Chunks.Clear();
+        }
 
-		public bool Read(BundleEntry entry, ILoader loader = null)
-		{
-			Clear();
+        public bool Read(BundleEntry entry, ILoader loader = null)
+        {
+            Clear();
 
-			MemoryStream ms = entry.MakeStream();
-			BinaryReader2 br = new BinaryReader2(ms);
-			br.BigEndian = entry.Console;
+            MemoryStream ms = entry.MakeStream();
+            BinaryReader2 br = new BinaryReader2(ms);
+            br.BigEndian = entry.Console;
 
-			Min = br.ReadVector3F();
-			Unknown4 = br.ReadInt32();
-			Max = br.ReadVector3F();
-			Unknown8 = br.ReadInt32();
-			uint chunkPointerStart = br.ReadUInt32();
-			uint boxListStart = br.ReadUInt32();
-			int chunkCount = br.ReadInt32();
-			br.ReadUInt32(); // FileSize
+            Min = br.ReadVector3F();
+            Unknown4 = br.ReadInt32();
+            Max = br.ReadVector3F();
+            Unknown8 = br.ReadInt32();
+            uint chunkPointerStart = br.ReadUInt32();
+            uint boxListStart = br.ReadUInt32();
+            int chunkCount = br.ReadInt32();
+            br.ReadUInt32(); // FileSize
 
-			List<uint> chunkPointers = new List<uint>();
+            List<uint> chunkPointers = new List<uint>();
 
-			// No Data
-			if (chunkCount == 0)
-			{
-				br.Close();
-				ms.Close();
-				return true;
-			}
+            // No Data
+            if (chunkCount == 0)
+            {
+                br.Close();
+                ms.Close();
+                return true;
+            }
 
-			br.BaseStream.Position = chunkPointerStart;
+            br.BaseStream.Position = chunkPointerStart;
 
-			for (int i = 0; i < chunkCount; i++)
-			{
-				chunkPointers.Add(br.ReadUInt32());
-			}
+            for (int i = 0; i < chunkCount; i++)
+            {
+                chunkPointers.Add(br.ReadUInt32());
+            }
 
-			for (int i = 0; i < chunkCount; i++)
-			{
-				// Read Vertically
+            for (int i = 0; i < chunkCount; i++)
+            {
+                // Read Vertically
 
-				long pos = boxListStart + 0x70 * (i / 4) + 4 * (i % 4);
+                long pos = boxListStart + 0x70 * (i / 4) + 4 * (i % 4);
 
-				BoxF boundingBox = new BoxF();
-				br.BaseStream.Position = pos;
-				float minX = br.ReadSingle();
-				br.BaseStream.Position += 12;
-				float minY = br.ReadSingle();
-				br.BaseStream.Position += 12;
-				float minZ = br.ReadSingle();
+                BoxF boundingBox = new BoxF();
+                br.BaseStream.Position = pos;
+                float minX = br.ReadSingle();
+                br.BaseStream.Position += 12;
+                float minY = br.ReadSingle();
+                br.BaseStream.Position += 12;
+                float minZ = br.ReadSingle();
 
-				boundingBox.Min = new Vector3(minX, minY, minZ);
+                boundingBox.Min = new Vector3(minX, minY, minZ);
 
-				br.BaseStream.Position += 12;
-				float maxX = br.ReadSingle();
-				br.BaseStream.Position += 12;
-				float maxY = br.ReadSingle();
-				br.BaseStream.Position += 12;
-				float maxZ = br.ReadSingle();
-				br.BaseStream.Position += 12;
+                br.BaseStream.Position += 12;
+                float maxX = br.ReadSingle();
+                br.BaseStream.Position += 12;
+                float maxY = br.ReadSingle();
+                br.BaseStream.Position += 12;
+                float maxZ = br.ReadSingle();
+                br.BaseStream.Position += 12;
 
-				boundingBox.Max = new Vector3(maxX, maxY, maxZ);
+                boundingBox.Max = new Vector3(maxX, maxY, maxZ);
 
-				PolygonSoupBoundingBox box = new PolygonSoupBoundingBox(boundingBox, br.ReadInt32());
+                PolygonSoupBoundingBox box = new PolygonSoupBoundingBox(boundingBox, br.ReadInt32());
 
-				BoundingBoxes.Add(box);
-			}
+                BoundingBoxes.Add(box);
+            }
 
-			for (int i = 0; i < chunkPointers.Count; i++)
-			{
-				br.BaseStream.Position = chunkPointers[i];
+            for (int i = 0; i < chunkPointers.Count; i++)
+            {
+                br.BaseStream.Position = chunkPointers[i];
 
-				Chunks.Add(PolygonSoupChunk.Read(br));
-			}
+                Chunks.Add(PolygonSoupChunk.Read(br));
+            }
 
-			br.Close();
-			ms.Close();
+            br.Close();
+            ms.Close();
 
-			return true;
-		}
+            return true;
+        }
 
-		public bool Write(BundleEntry entry)
-		{
-			MemoryStream ms = new MemoryStream();
-			BinaryWriter bw = new BinaryWriter(ms);
+        public bool Write(BundleEntry entry)
+        {
+            MemoryStream ms = new MemoryStream();
+            BinaryWriter bw = new BinaryWriter(ms);
 
-			bw.Write(Min);
-			bw.Write(Unknown4);
-			bw.Write(Max);
-			bw.Write(Unknown8);
-			long chunkPointerStartPos = bw.BaseStream.Position;
-			bw.Write((uint)0);
-			long boxListStartPos = bw.BaseStream.Position;
-			bw.Write((uint)0);
-			bw.Write(Chunks.Count);
-			long fileSizePos = bw.BaseStream.Position;
-			bw.Write((uint)0);
+            bw.Write(Min);
+            bw.Write(Unknown4);
+            bw.Write(Max);
+            bw.Write(Unknown8);
+            long chunkPointerStartPos = bw.BaseStream.Position;
+            bw.Write((uint)0);
+            long boxListStartPos = bw.BaseStream.Position;
+            bw.Write((uint)0);
+            bw.Write(Chunks.Count);
+            long fileSizePos = bw.BaseStream.Position;
+            bw.Write((uint)0);
 
-			uint[] chunkPointers = new uint[Chunks.Count];
+            uint[] chunkPointers = new uint[Chunks.Count];
 
-			// No Data
-			if (Chunks.Count == 0)
-			{
-				bw.Flush();
-				byte[] data2 = ms.ToArray();
-				bw.Close();
-				ms.Close();
+            // No Data
+            if (Chunks.Count == 0)
+            {
+                bw.Flush();
+                byte[] data2 = ms.ToArray();
+                bw.Close();
+                ms.Close();
 
-				entry.EntryBlocks[0].Data = data2;
-				entry.Dirty = true;
-				return true;
-			}
+                entry.EntryBlocks[0].Data = data2;
+                entry.Dirty = true;
+                return true;
+            }
 
-			long cPos = bw.BaseStream.Position;
-			uint chunkPointerStart = (uint)bw.BaseStream.Position;
-			bw.BaseStream.Position = chunkPointerStartPos;
-			bw.Write((uint)cPos);
-			bw.BaseStream.Position = cPos;
+            long cPos = bw.BaseStream.Position;
+            uint chunkPointerStart = (uint)bw.BaseStream.Position;
+            bw.BaseStream.Position = chunkPointerStartPos;
+            bw.Write((uint)cPos);
+            bw.BaseStream.Position = cPos;
 
-			for (int i = 0; i < Chunks.Count; i++)
-			{
-				bw.Write((uint)0);
-			}
+            for (int i = 0; i < Chunks.Count; i++)
+            {
+                bw.Write((uint)0);
+            }
 
-			bw.BaseStream.Position = (16 * ((bw.BaseStream.Position + 15) / 16));
-			cPos = bw.BaseStream.Position;
-			uint boxListStart = (uint)bw.BaseStream.Position;
-			bw.BaseStream.Position = boxListStartPos;
-			bw.Write((uint)cPos);
+            bw.BaseStream.Position = (16 * ((bw.BaseStream.Position + 15) / 16));
+            cPos = bw.BaseStream.Position;
+            uint boxListStart = (uint)bw.BaseStream.Position;
+            bw.BaseStream.Position = boxListStartPos;
+            bw.Write((uint)cPos);
 
-			for (int i = 0; i < Chunks.Count; i++)
-			{
-				// Write Vertically
+            for (int i = 0; i < Chunks.Count; i++)
+            {
+                // Write Vertically
 
-				long pos = boxListStart + 0x70 * (i / 4) + 4 * (i % 4);
+                long pos = boxListStart + 0x70 * (i / 4) + 4 * (i % 4);
 
-				PolygonSoupBoundingBox box = BoundingBoxes[i];
+                PolygonSoupBoundingBox box = BoundingBoxes[i];
 
-				bw.BaseStream.Position = pos;
-				bw.Write(box.Box.Min.X);
-				bw.BaseStream.Position += 12;
-				bw.Write(box.Box.Min.Y);
-				bw.BaseStream.Position += 12;
-				bw.Write(box.Box.Min.Z);
+                bw.BaseStream.Position = pos;
+                bw.Write(box.Box.Min.X);
+                bw.BaseStream.Position += 12;
+                bw.Write(box.Box.Min.Y);
+                bw.BaseStream.Position += 12;
+                bw.Write(box.Box.Min.Z);
 
-				bw.BaseStream.Position += 12;
-				bw.Write(box.Box.Max.X);
-				bw.BaseStream.Position += 12;
-				bw.Write(box.Box.Max.Y);
-				bw.BaseStream.Position += 12;
-				bw.Write(box.Box.Max.Z);
+                bw.BaseStream.Position += 12;
+                bw.Write(box.Box.Max.X);
+                bw.BaseStream.Position += 12;
+                bw.Write(box.Box.Max.Y);
+                bw.BaseStream.Position += 12;
+                bw.Write(box.Box.Max.Z);
 
-				bw.BaseStream.Position += 12;
-				bw.Write(box.Terminator);
-			}
+                bw.BaseStream.Position += 12;
+                bw.Write(box.Terminator);
+            }
 
-			bw.BaseStream.Position = (16 * ((bw.BaseStream.Position + 15) / 16));
+            bw.BaseStream.Position = (16 * ((bw.BaseStream.Position + 15) / 16));
 
-			if (Chunks.Count > 0)
-			{
-				bw.BaseStream.Position = (128 * ((bw.BaseStream.Position + 127) / 128));
+            if (Chunks.Count > 0)
+            {
+                bw.BaseStream.Position = (128 * ((bw.BaseStream.Position + 127) / 128));
 
-				for (int i = 0; i < Chunks.Count / 4; i++)
-				{
-					if ((i % 8) % 3 == 0)
-					{
-						bw.BaseStream.Position += 256;
-					}
-					else
-					{
-						bw.BaseStream.Position += 384;
-					}
-				}
-			}
+                for (int i = 0; i < Chunks.Count / 4; i++)
+                {
+                    if ((i % 8) % 3 == 0)
+                    {
+                        bw.BaseStream.Position += 256;
+                    }
+                    else
+                    {
+                        bw.BaseStream.Position += 384;
+                    }
+                }
+            }
 
-			for (int i = 0; i < chunkPointers.Length; i++)
-			{
-				bw.BaseStream.Position = (128 * ((bw.BaseStream.Position + 127) / 128));
+            for (int i = 0; i < chunkPointers.Length; i++)
+            {
+                bw.BaseStream.Position = (128 * ((bw.BaseStream.Position + 127) / 128));
 
-				chunkPointers[i] = (uint)bw.BaseStream.Position;
+                chunkPointers[i] = (uint)bw.BaseStream.Position;
 
-				Chunks[i].Write(bw);
-			}
+                Chunks[i].Write(bw);
+            }
 
-			bw.BaseStream.Position = (16 * ((bw.BaseStream.Position + 15) / 16)) + 0x5F;
-			bw.Write((byte)0);
+            bw.BaseStream.Position = (16 * ((bw.BaseStream.Position + 15) / 16)) + 0x5F;
+            bw.Write((byte)0);
 
-			cPos = bw.BaseStream.Position;
-			bw.BaseStream.Position = fileSizePos;
-			bw.Write((uint)cPos);
+            cPos = bw.BaseStream.Position;
+            bw.BaseStream.Position = fileSizePos;
+            bw.Write((uint)cPos);
 
-			bw.BaseStream.Position = chunkPointerStart;
-			for (int i = 0; i < Chunks.Count; i++)
-			{
-				bw.Write(chunkPointers[i]);
-			}
+            bw.BaseStream.Position = chunkPointerStart;
+            for (int i = 0; i < Chunks.Count; i++)
+            {
+                bw.Write(chunkPointers[i]);
+            }
 
-			bw.Flush();
-			byte[] data = ms.ToArray();
-			bw.Close();
-			ms.Close();
+            bw.Flush();
+            byte[] data = ms.ToArray();
+            bw.Close();
+            ms.Close();
 
-			entry.EntryBlocks[0].Data = data;
-			entry.Dirty = true;
+            entry.EntryBlocks[0].Data = data;
+            entry.Dirty = true;
 
-			return true;
-		}
+            return true;
+        }
 
-		public EntryType GetEntryType(BundleEntry entry)
-		{
-			return EntryType.PolygonSoupList;
-		}
+        public EntryType GetEntryType(BundleEntry entry)
+        {
+            return EntryType.PolygonSoupList;
+        }
 
-		public IEntryEditor GetEditor(BundleEntry entry)
-		{
-			WorldColEditor editor = new WorldColEditor();
-			editor.Poly = this;
-			editor.Changed += () =>
-			{
-				Write(entry);
-			};
+        public IEntryEditor GetEditor(BundleEntry entry)
+        {
+            WorldColEditor editor = new WorldColEditor();
+            editor.Poly = this;
+            editor.Changed += () =>
+            {
+                Write(entry);
+            };
 
-			return editor;
-		}
-	}
+            return editor;
+        }
+    }
 }

--- a/WorldCollisionHandler/WorldCollisionPlugin.cs
+++ b/WorldCollisionHandler/WorldCollisionPlugin.cs
@@ -12,133 +12,133 @@ using System.Windows.Forms;
 
 namespace WorldCollisionHandler
 {
-	public class WorldCollisionPlugin : Plugin
-	{
-		public override void Init()
-		{
-			EntryTypeRegistry.Register(EntryType.PolygonSoupList, new PolygonSoupList());
+    public class WorldCollisionPlugin : Plugin
+    {
+        public override void Init()
+        {
+            EntryTypeRegistry.Register(EntryType.PolygonSoupList, new PolygonSoupList());
 
-			PluginCommandRegistry.Register("dump_all_collisions", "Dump All Collisions", DumpAllCollisions, IsWorldCol);
-			PluginCommandRegistry.Register("remove_wreck_surfaces", "Remove Wreck Surfaces", RemoveWreckSurfaces, IsWorldCol);
-		}
+            PluginCommandRegistry.Register("dump_all_collisions", "Dump All Collisions", DumpAllCollisions, IsWorldCol);
+            PluginCommandRegistry.Register("remove_wreck_surfaces", "Remove Wreck Surfaces", RemoveWreckSurfaces, IsWorldCol);
+        }
 
-		public override string GetID()
-		{
-			return "worldcolplugin";
-		}
+        public override string GetID()
+        {
+            return "worldcolplugin";
+        }
 
-		public override string GetName()
-		{
-			return "World Collision Handler";
-		}
+        public override string GetName()
+        {
+            return "World Collision Handler";
+        }
 
-		#region Extra Tools
+        #region Extra Tools
 
-		private bool IsWorldCol(BundleArchive archive)
-		{
-			for (int i = 0; i < archive.Entries.Count; i++)
-			{
-				BundleEntry entry = archive.Entries[i];
+        private bool IsWorldCol(BundleArchive archive)
+        {
+            for (int i = 0; i < archive.Entries.Count; i++)
+            {
+                BundleEntry entry = archive.Entries[i];
 
-				if (entry.Type == EntryType.PolygonSoupList)
-					return true;
-			}
+                if (entry.Type == EntryType.PolygonSoupList)
+                    return true;
+            }
 
-			return false;
-		}
+            return false;
+        }
 
-		private void DumpAllCollisions(IWin32Window window, BundleArchive archive)
-		{
-			if (archive == null)
-				return;
+        private void DumpAllCollisions(IWin32Window window, BundleArchive archive)
+        {
+            if (archive == null)
+                return;
 
-			FolderBrowserDialog fbd = new FolderBrowserDialog();
-			DialogResult result = fbd.ShowDialog(window);
-			if (result == DialogResult.OK)
-			{
-				string path = fbd.SelectedPath;
+            FolderBrowserDialog fbd = new FolderBrowserDialog();
+            DialogResult result = fbd.ShowDialog(window);
+            if (result == DialogResult.OK)
+            {
+                string path = fbd.SelectedPath;
 
-				for (int i = 0; ; i++)
-				{
-					string idListName = "trk_clil" + i;
-					string polyName = "trk_col_" + i;
+                for (int i = 0; ; i++)
+                {
+                    string idListName = "trk_clil" + i;
+                    string polyName = "trk_col_" + i;
 
-					ulong idListID = Crc32.HashCrc32B(idListName);
-					ulong polyID = Crc32.HashCrc32B(polyName);
+                    ulong idListID = Crc32.HashCrc32B(idListName);
+                    ulong polyID = Crc32.HashCrc32B(polyName);
 
-					BundleEntry entry = archive.GetEntryByID(idListID);
-					if (entry == null)
-						break;
-					Stream outFile = File.Open(path + "/" + idListName + ".bin", FileMode.Create, FileAccess.Write);
-					BinaryWriter bw = new BinaryWriter(outFile);
-					bw.Write(entry.EntryBlocks[0].Data);
-					bw.Flush();
-					bw.Close();
-					outFile.Close();
+                    BundleEntry entry = archive.GetEntryByID(idListID);
+                    if (entry == null)
+                        break;
+                    Stream outFile = File.Open(path + "/" + idListName + ".bin", FileMode.Create, FileAccess.Write);
+                    BinaryWriter bw = new BinaryWriter(outFile);
+                    bw.Write(entry.EntryBlocks[0].Data);
+                    bw.Flush();
+                    bw.Close();
+                    outFile.Close();
 
-					BundleEntry polyEntry = archive.GetEntryByID(polyID);
-					if (polyEntry == null)
-						break;
-					Stream outFilePoly = File.Open(path + "/" + polyName + ".bin", FileMode.Create, FileAccess.Write);
-					BinaryWriter bwPoly = new BinaryWriter(outFilePoly);
-					bwPoly.Write(polyEntry.EntryBlocks[0].Data);
-					bwPoly.Flush();
-					bwPoly.Close();
-					outFilePoly.Close();
+                    BundleEntry polyEntry = archive.GetEntryByID(polyID);
+                    if (polyEntry == null)
+                        break;
+                    Stream outFilePoly = File.Open(path + "/" + polyName + ".bin", FileMode.Create, FileAccess.Write);
+                    BinaryWriter bwPoly = new BinaryWriter(outFilePoly);
+                    bwPoly.Write(polyEntry.EntryBlocks[0].Data);
+                    bwPoly.Flush();
+                    bwPoly.Close();
+                    outFilePoly.Close();
 
-					PolygonSoupList poly = new PolygonSoupList();
-					poly.Read(polyEntry);
-					Scene scene = poly.MakeScene();
-					scene.ExportWavefrontObj(path + "/" + polyName + ".obj");
-				}
+                    PolygonSoupList poly = new PolygonSoupList();
+                    poly.Read(polyEntry);
+                    Scene scene = poly.MakeScene();
+                    scene.ExportWavefrontObj(path + "/" + polyName + ".obj");
+                }
 
-				MessageBox.Show(window, "Done!", "Success", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
-			}
-		}
+                MessageBox.Show(window, "Done!", "Success", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+            }
+        }
 
-		private void RemoveWreckSurfaces(IWin32Window window, BundleArchive archive)
-		{
-			for (int i = 0; i < archive.Entries.Count; i++)
-			{
-				BundleEntry entry = archive.Entries[i];
+        private void RemoveWreckSurfaces(IWin32Window window, BundleArchive archive)
+        {
+            for (int i = 0; i < archive.Entries.Count; i++)
+            {
+                BundleEntry entry = archive.Entries[i];
 
-				if (entry.Type == EntryType.PolygonSoupList)
-				{
-					PolygonSoupList list = new PolygonSoupList();
-					list.Read(entry);
-					list.RemoveWreckSurfaces();
-					list.Write(entry);
-				}
-			}
-		}
+                if (entry.Type == EntryType.PolygonSoupList)
+                {
+                    PolygonSoupList list = new PolygonSoupList();
+                    list.Read(entry);
+                    list.RemoveWreckSurfaces();
+                    list.Write(entry);
+                }
+            }
+        }
 
-		/*public void ConvertToPC(IWin32Window window, BundleArchive archive)
-		{
-			// TODO: Support everything
+        /*public void ConvertToPC(IWin32Window window, BundleArchive archive)
+        {
+            // TODO: Support everything
 
-			for (int i = 0; i < archive.Entries.Count; i++)
-			{
-				BundleEntry entry = archive.Entries[i];
+            for (int i = 0; i < archive.Entries.Count; i++)
+            {
+                BundleEntry entry = archive.Entries[i];
 
-				if (entry.Type == EntryType.IDList)
-				{
-					IDList list = new IDList();
-					list.Read(entry);
-					list.Write(entry);
-				}
-				else if (entry.Type == EntryType.PolygonSoupListResourceType)
-				{
-					PolygonSoupList list = new PolygonSoupList();
-					list.Read(entry);
-					list.Write(entry);
-				}
-			}
+                if (entry.Type == EntryType.IDList)
+                {
+                    IDList list = new IDList();
+                    list.Read(entry);
+                    list.Write(entry);
+                }
+                else if (entry.Type == EntryType.PolygonSoupListResourceType)
+                {
+                    PolygonSoupList list = new PolygonSoupList();
+                    list.Read(entry);
+                    list.Write(entry);
+                }
+            }
 
-			//PatchImages();
+            //PatchImages();
 
-			archive.Platform = BundlePlatform.PC;
-		}*/
+            archive.Platform = BundlePlatform.PC;
+        }*/
 
-		#endregion
-	}
+        #endregion
+    }
 }


### PR DESCRIPTION
Created an EditorConfig which forces 4 spaces per indent. Also did a bulk replace of tabs with 4 spaces in .cs files. Other file types are left as-is as they are not typically edited directly. If need be, they can be added to this PR.

Previously, around 3/4 indents used spaces, while the remaining indents used tabs. Some files contained mixed indentation.

This needs to be reviewed to ensure there are no issues caused by the bulk replace.