### PR TITLE
Fix Trigger, LuaList, and AttribSys saving

### DIFF
--- a/BaseHandlers/TriggerDataEditor.Designer.cs
+++ b/BaseHandlers/TriggerDataEditor.Designer.cs
@@ -31,7 +31,6 @@ namespace BaseHandlers
             this.propertyGrid1.Name = "propertyGrid1";
             this.propertyGrid1.Size = new System.Drawing.Size(802, 456);
             this.propertyGrid1.TabIndex = 0;
-            this.propertyGrid1.PropertyValueChanged += new System.Windows.Forms.PropertyValueChangedEventHandler(this.propertyGrid1_PropertyValueChanged);
             // 
             // TriggerDataEditor
             // 
@@ -41,6 +40,7 @@ namespace BaseHandlers
             this.Controls.Add(this.propertyGrid1);
             this.Name = "TriggerDataEditor";
             this.Text = "Trigger Data Editor";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.TriggerDataEditor_FormClosed);
             this.ResumeLayout(false);
 
         }

--- a/BaseHandlers/TriggerDataEditor.cs
+++ b/BaseHandlers/TriggerDataEditor.cs
@@ -35,7 +35,7 @@ namespace BaseHandlers
             UpdateComponent();
         }
 
-        private void propertyGrid1_PropertyValueChanged(object s, PropertyValueChangedEventArgs e)
+        private void TriggerDataEditor_FormClosed(object s, FormClosedEventArgs e)
         {
             EditEvent?.Invoke();
         }

--- a/LuaList/LuaListEditor.Designer.cs
+++ b/LuaList/LuaListEditor.Designer.cs
@@ -32,7 +32,6 @@ namespace LuaList
             this.propertyGrid1.Name = "propertyGrid1";
             this.propertyGrid1.Size = new System.Drawing.Size(802, 456);
             this.propertyGrid1.TabIndex = 0;
-            this.propertyGrid1.PropertyValueChanged += new System.Windows.Forms.PropertyValueChangedEventHandler(this.propertyGrid1_PropertyValueChanged);
             // 
             // LuaListEditor
             // 
@@ -42,6 +41,7 @@ namespace LuaList
             this.Controls.Add(this.propertyGrid1);
             this.Name = "LuaListEditor";
             this.Text = "Lua List Editor";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.LuaListEditor_FormClosed);
             this.ResumeLayout(false);
 
             this.Controls.Add(this.propertyGrid1);

--- a/LuaList/LuaListEditor.cs
+++ b/LuaList/LuaListEditor.cs
@@ -21,7 +21,6 @@ namespace LuaList
 
         public void UpdateComponent()
         {
-           
             propertyGrid1.SelectedObject = LuaList;
         }
 
@@ -31,10 +30,9 @@ namespace LuaList
             UpdateComponent();
         }
 
-        private void propertyGrid1_PropertyValueChanged(object s, PropertyValueChangedEventArgs e)
+        private void LuaListEditor_FormClosed(object s, FormClosedEventArgs e)
         {
             EditEvent?.Invoke();
         }
-
     }
 }

--- a/VaultFormat/AttribSysVaultForm.Designer.cs
+++ b/VaultFormat/AttribSysVaultForm.Designer.cs
@@ -119,7 +119,6 @@ namespace VaultFormat
             this.propertyGrid2.Name = "propertyGrid2";
             this.propertyGrid2.Size = new System.Drawing.Size(1312, 752);
             this.propertyGrid2.TabIndex = 6;
-            this.propertyGrid2.PropertyValueChanged += new System.Windows.Forms.PropertyValueChangedEventHandler(this.propertyGrid2_PropertyValueChanged);
             // 
             // AttribSysVaultForm
             // 
@@ -133,6 +132,7 @@ namespace VaultFormat
             this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.Name = "AttribSysVaultForm";
             this.Text = "AttribSysVault Editor";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.AttribSysVaultForm_FormClosed);
             this.menu.ResumeLayout(false);
             this.menu.PerformLayout();
             this.contextMenu.ResumeLayout(false);

--- a/VaultFormat/AttribSysVaultForm.cs
+++ b/VaultFormat/AttribSysVaultForm.cs
@@ -29,7 +29,6 @@ namespace VaultFormat
             }
         }
 
-
         private void UpdateDisplay()
         {
             lstDataChunks.Items.Clear();
@@ -125,12 +124,10 @@ namespace VaultFormat
             propertyGrid2.SelectedObject = AttribSys.Attributes[index];
         }
 
-        private void propertyGrid2_PropertyValueChanged(object s, PropertyValueChangedEventArgs e)
+        private void AttribSysVaultForm_FormClosed(object s, FormClosedEventArgs e)
         {
             EditEvent?.Invoke();
             UpdateDisplay();
         }
-
     }
-
 }


### PR DESCRIPTION
These were using `PropertyValueChanged`, which applied only to the main property grid. When changes were made in another window, such as a collection editor, and no changes were made in the property grid, all changes would be lost upon closing. They now use `FormClosed`.