### PR TITLE
PVS editor update

### DIFF
--- a/PVSFormat/AddZone.Designer.cs
+++ b/PVSFormat/AddZone.Designer.cs
@@ -58,7 +58,7 @@
             // zoneIdNumericUpDown
             // 
             zoneIdNumericUpDown.Location = new System.Drawing.Point(42, 32);
-            zoneIdNumericUpDown.Maximum = new decimal(new int[] { 1024, 0, 0, 0 });
+            zoneIdNumericUpDown.Maximum = new decimal(new int[] { 512, 0, 0, 0 });
             zoneIdNumericUpDown.Name = "zoneIdNumericUpDown";
             zoneIdNumericUpDown.Size = new System.Drawing.Size(100, 23);
             zoneIdNumericUpDown.TabIndex = 2;

--- a/PVSFormat/AddZone.cs
+++ b/PVSFormat/AddZone.cs
@@ -26,6 +26,7 @@ namespace PVSFormat
 
         private void cancelButton_Click(object sender, EventArgs e)
         {
+            zone = ulong.MaxValue;
             Close();
         }
     }

--- a/PVSFormat/PVSEditControl.cs
+++ b/PVSFormat/PVSEditControl.cs
@@ -39,7 +39,7 @@ namespace PVSFormat
             Neighbour
         }
 
-        protected PointF MousePosOnMap
+        internal PointF MousePosOnMap
         {
             get
             {

--- a/PVSFormat/PVSEditor.Designer.cs
+++ b/PVSFormat/PVSEditor.Designer.cs
@@ -126,14 +126,15 @@ namespace PVSFormat
             pvsMain.PVS = null;
             pvsMain.Size = new System.Drawing.Size(580, 561);
             pvsMain.TabIndex = 0;
+            pvsMain.Click += pvsMain_Click;
             pvsMain.DoubleClick += pvsMain_DoubleClick;
             // 
             // deleteZoneButton
             // 
             deleteZoneButton.Enabled = false;
-            deleteZoneButton.Location = new System.Drawing.Point(136, 8);
+            deleteZoneButton.Location = new System.Drawing.Point(131, 8);
             deleteZoneButton.Name = "deleteZoneButton";
-            deleteZoneButton.Size = new System.Drawing.Size(48, 23);
+            deleteZoneButton.Size = new System.Drawing.Size(56, 23);
             deleteZoneButton.TabIndex = 28;
             deleteZoneButton.Text = "Delete";
             deleteZoneButton.UseVisualStyleBackColor = true;
@@ -141,9 +142,9 @@ namespace PVSFormat
             // 
             // addZoneButton
             // 
-            addZoneButton.Location = new System.Drawing.Point(16, 8);
+            addZoneButton.Location = new System.Drawing.Point(11, 8);
             addZoneButton.Name = "addZoneButton";
-            addZoneButton.Size = new System.Drawing.Size(48, 23);
+            addZoneButton.Size = new System.Drawing.Size(56, 23);
             addZoneButton.TabIndex = 27;
             addZoneButton.Text = "Add";
             addZoneButton.UseVisualStyleBackColor = true;
@@ -163,9 +164,9 @@ namespace PVSFormat
             // deleteNeighbourButton
             // 
             deleteNeighbourButton.Enabled = false;
-            deleteNeighbourButton.Location = new System.Drawing.Point(135, 353);
+            deleteNeighbourButton.Location = new System.Drawing.Point(131, 353);
             deleteNeighbourButton.Name = "deleteNeighbourButton";
-            deleteNeighbourButton.Size = new System.Drawing.Size(48, 23);
+            deleteNeighbourButton.Size = new System.Drawing.Size(56, 23);
             deleteNeighbourButton.TabIndex = 24;
             deleteNeighbourButton.Text = "Delete";
             deleteNeighbourButton.UseVisualStyleBackColor = true;
@@ -174,9 +175,9 @@ namespace PVSFormat
             // addNeighbourButton
             // 
             addNeighbourButton.Enabled = false;
-            addNeighbourButton.Location = new System.Drawing.Point(15, 353);
+            addNeighbourButton.Location = new System.Drawing.Point(11, 353);
             addNeighbourButton.Name = "addNeighbourButton";
-            addNeighbourButton.Size = new System.Drawing.Size(48, 23);
+            addNeighbourButton.Size = new System.Drawing.Size(56, 23);
             addNeighbourButton.TabIndex = 23;
             addNeighbourButton.Text = "Add";
             addNeighbourButton.UseVisualStyleBackColor = true;
@@ -266,7 +267,7 @@ namespace PVSFormat
             // neighboursLabel
             // 
             neighboursLabel.AutoSize = true;
-            neighboursLabel.Location = new System.Drawing.Point(64, 357);
+            neighboursLabel.Location = new System.Drawing.Point(65, 357);
             neighboursLabel.Name = "neighboursLabel";
             neighboursLabel.Size = new System.Drawing.Size(69, 15);
             neighboursLabel.TabIndex = 13;
@@ -415,13 +416,13 @@ namespace PVSFormat
             // 
             // PVSEditor
             // 
-            FormClosing += PVSEditor_FormClosing;
             AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             ClientSize = new System.Drawing.Size(784, 561);
             Controls.Add(pvsSplitContainer);
             Name = "PVSEditor";
             Text = "PVS Editor";
+            FormClosing += PVSEditor_FormClosing;
             pvsSplitContainer.Panel1.ResumeLayout(false);
             pvsSplitContainer.Panel2.ResumeLayout(false);
             pvsSplitContainer.Panel2.PerformLayout();

--- a/PVSFormat/PVSEditor.cs
+++ b/PVSFormat/PVSEditor.cs
@@ -102,7 +102,7 @@ namespace PVSFormat
             Edit?.Invoke();
         }
 
-        private void pvsMain_DoubleClick(object sender, System.EventArgs e)
+        private void pvsMain_DoubleClick(object sender, EventArgs e)
         {
             ulong zoneId = pvsMain.GetZoneId();
             if (zoneId == ulong.MaxValue)
@@ -111,7 +111,46 @@ namespace PVSFormat
             zonesListBox.SelectedIndex = zonesListBox.FindStringExact(zoneId.ToString("000"));
         }
 
-        private void zonesListBox_SelectedIndexChanged(object sender, System.EventArgs e)
+        private void pvsMain_Click(object sender, EventArgs e)
+        {
+            if (((MouseEventArgs)e).Button == MouseButtons.Right
+                && pvsMain.PVS.selectedZoneId != ulong.MaxValue)
+                OpenContextMenu();
+        }
+
+        private void OpenContextMenu()
+        {
+            ContextMenuStrip menu = new();
+            for (int i = 0; i < 4; ++i)
+                menu.Items.Add("Use as point " + (i + 1).ToString());
+            menu.Items[0].Click += (s, e) =>
+            {
+                Vector2 pos = pvsMain.MousePosOnMap.ToVector2();
+                point1XNumericUpDown.Value = (decimal)pos.X;
+                point1YNumericUpDown.Value = (decimal)pos.Y;
+            };
+            menu.Items[1].Click += (s, e) =>
+            {
+                Vector2 pos = pvsMain.MousePosOnMap.ToVector2();
+                point2XNumericUpDown.Value = (decimal)pos.X;
+                point2YNumericUpDown.Value = (decimal)pos.Y;
+            };
+            menu.Items[2].Click += (s, e) =>
+            {
+                Vector2 pos = pvsMain.MousePosOnMap.ToVector2();
+                point3XNumericUpDown.Value = (decimal)pos.X;
+                point3YNumericUpDown.Value = (decimal)pos.Y;
+            };
+            menu.Items[3].Click += (s, e) =>
+            {
+                Vector2 pos = pvsMain.MousePosOnMap.ToVector2();
+                point4XNumericUpDown.Value = (decimal)pos.X;
+                point4YNumericUpDown.Value = (decimal)pos.Y;
+            };
+            menu.Show(Cursor.Position);
+        }
+
+        private void zonesListBox_SelectedIndexChanged(object sender, EventArgs e)
         {
             if (zonesListBox.SelectedIndex == -1)
                 return;
@@ -121,7 +160,7 @@ namespace PVSFormat
             deleteZoneButton.Enabled = true;
         }
 
-        private void addZoneButton_Click(object sender, System.EventArgs e)
+        private void addZoneButton_Click(object sender, EventArgs e)
         {
             var zones = GetZones();
             ulong newZoneId;
@@ -149,7 +188,7 @@ namespace PVSFormat
                 deleteZoneButton.Enabled = true;
         }
 
-        private void deleteZoneButton_Click(object sender, System.EventArgs e)
+        private void deleteZoneButton_Click(object sender, EventArgs e)
         {
             int index = zonesListBox.SelectedIndex;
             ulong zoneId = ulong.Parse(zonesListBox.Items[index].ToString());
@@ -168,7 +207,7 @@ namespace PVSFormat
                 zonesListBox.SelectedIndex = index;
         }
 
-        private void point1XNumericUpDown_ValueChanged(object sender, System.EventArgs e)
+        private void point1XNumericUpDown_ValueChanged(object sender, EventArgs e)
         {
             Vector2 point = GetPoints()[0];
             point.X = (float)point1XNumericUpDown.Value;
@@ -176,7 +215,7 @@ namespace PVSFormat
             pvsMain.Invalidate();
         }
 
-        private void point1YNumericUpDown_ValueChanged(object sender, System.EventArgs e)
+        private void point1YNumericUpDown_ValueChanged(object sender, EventArgs e)
         {
             Vector2 point = GetPoints()[0];
             point.Y = (float)point1YNumericUpDown.Value;
@@ -184,7 +223,7 @@ namespace PVSFormat
             pvsMain.Invalidate();
         }
 
-        private void point2XNumericUpDown_ValueChanged(object sender, System.EventArgs e)
+        private void point2XNumericUpDown_ValueChanged(object sender, EventArgs e)
         {
             Vector2 point = GetPoints()[1];
             point.X = (float)point2XNumericUpDown.Value;
@@ -192,7 +231,7 @@ namespace PVSFormat
             pvsMain.Invalidate();
         }
 
-        private void point2YNumericUpDown_ValueChanged(object sender, System.EventArgs e)
+        private void point2YNumericUpDown_ValueChanged(object sender, EventArgs e)
         {
             Vector2 point = GetPoints()[1];
             point.Y = (float)point2YNumericUpDown.Value;
@@ -200,7 +239,7 @@ namespace PVSFormat
             pvsMain.Invalidate();
         }
 
-        private void point3XNumericUpDown_ValueChanged(object sender, System.EventArgs e)
+        private void point3XNumericUpDown_ValueChanged(object sender, EventArgs e)
         {
             Vector2 point = GetPoints()[2];
             point.X = (float)point3XNumericUpDown.Value;
@@ -208,7 +247,7 @@ namespace PVSFormat
             pvsMain.Invalidate();
         }
 
-        private void point3YNumericUpDown_ValueChanged(object sender, System.EventArgs e)
+        private void point3YNumericUpDown_ValueChanged(object sender, EventArgs e)
         {
             Vector2 point = GetPoints()[2];
             point.Y = (float)point3YNumericUpDown.Value;
@@ -216,7 +255,7 @@ namespace PVSFormat
             pvsMain.Invalidate();
         }
 
-        private void point4XNumericUpDown_ValueChanged(object sender, System.EventArgs e)
+        private void point4XNumericUpDown_ValueChanged(object sender, EventArgs e)
         {
             Vector2 point = GetPoints()[3];
             point.X = (float)point4XNumericUpDown.Value;
@@ -224,7 +263,7 @@ namespace PVSFormat
             pvsMain.Invalidate();
         }
 
-        private void point4YNumericUpDown_ValueChanged(object sender, System.EventArgs e)
+        private void point4YNumericUpDown_ValueChanged(object sender, EventArgs e)
         {
             Vector2 point = GetPoints()[3];
             point.Y = (float)point4YNumericUpDown.Value;
@@ -232,7 +271,7 @@ namespace PVSFormat
             pvsMain.Invalidate();
         }
 
-        private void neighboursListBox_SelectedIndexChanged(object sender, System.EventArgs e)
+        private void neighboursListBox_SelectedIndexChanged(object sender, EventArgs e)
         {
             if (neighboursListBox.SelectedIndex == -1)
                 return;
@@ -247,7 +286,7 @@ namespace PVSFormat
             immediateCheckBox.Enabled = true;
         }
 
-        private void addNeighbourButton_Click(object sender, System.EventArgs e)
+        private void addNeighbourButton_Click(object sender, EventArgs e)
         {
             ulong newZoneId = new AddZone().GetNewZoneId();
             if (newZoneId == ulong.MaxValue)
@@ -268,7 +307,7 @@ namespace PVSFormat
                 deleteNeighbourButton.Enabled = true;
         }
 
-        private void deleteNeighbourButton_Click(object sender, System.EventArgs e)
+        private void deleteNeighbourButton_Click(object sender, EventArgs e)
         {
             int index = neighboursListBox.SelectedIndex;
             ulong zoneId = ulong.Parse(neighboursListBox.Items[index].ToString());
@@ -295,7 +334,7 @@ namespace PVSFormat
                 neighboursListBox.SelectedIndex = index;
         }
 
-        private void renderCheckBox_CheckedChanged(object sender, System.EventArgs e)
+        private void renderCheckBox_CheckedChanged(object sender, EventArgs e)
         {
             if (neighboursListBox.SelectedIndex == -1)
                 return;
@@ -308,7 +347,7 @@ namespace PVSFormat
             GetUnsafeNeighbours()[neighbourIndex] = neighbour;
         }
 
-        private void immediateCheckBox_CheckedChanged(object sender, System.EventArgs e)
+        private void immediateCheckBox_CheckedChanged(object sender, EventArgs e)
         {
             if (neighboursListBox.SelectedIndex == -1)
                 return;

--- a/PVSFormat/PVSEditor.cs
+++ b/PVSFormat/PVSEditor.cs
@@ -135,6 +135,9 @@ namespace PVSFormat
                 }
                 break;
             }
+            if (newZoneId == ulong.MaxValue)
+                return;
+
             Zone newZone = new();
             newZone.ZoneId = newZoneId;
             zones.Add(newZone);
@@ -247,6 +250,8 @@ namespace PVSFormat
         private void addNeighbourButton_Click(object sender, System.EventArgs e)
         {
             ulong newZoneId = new AddZone().GetNewZoneId();
+            if (newZoneId == ulong.MaxValue)
+                return;
             var neighbours = GetUnsafeNeighbours();
             Neighbour newNeighbour = new();
             newNeighbour.ZoneId = newZoneId;


### PR DESCRIPTION
- Adds context menu for repositioning points
- Limits zone IDs to 512 max
- Fixes the cancel button not actually cancelling in the add zone dialog
- Hopefully fixes the delete button text on high DPI displays