### PR TITLE
Various UI changes/fixes

### DIFF
--- a/BundleManager/ViewModels/MainWindow.cs
+++ b/BundleManager/ViewModels/MainWindow.cs
@@ -128,9 +128,8 @@ public partial class MainWindow : ObservableObject
 
 	private void OnAddTreeNode(object sender, FileSystemEventArgs e)
 	{
-		Dispatcher.UIThread.Post(async () =>
+		Dispatcher.UIThread.Post(() =>
 		{
-			await Task.Delay(5000);
 			AddTreeNode(e.FullPath);
 		});
 	}

--- a/BundleManager/Views/MainWindow.axaml
+++ b/BundleManager/Views/MainWindow.axaml
@@ -93,6 +93,7 @@
 			<TreeView ItemsSource="{Binding GameDirectoryContents}"
 					  SelectedItem="{Binding SelectedNode, Mode=TwoWay}"
 					  Background="DimGray"
+					  ScrollViewer.AllowAutoHide="False"
 					  Grid.Column="0">
 				<TreeView.ItemTemplate>
 					<TreeDataTemplate ItemsSource="{Binding Entries}">

--- a/BundleManager/Views/MainWindow.axaml
+++ b/BundleManager/Views/MainWindow.axaml
@@ -84,7 +84,7 @@
 			<!-- Full column definitions are needed to bind widths. -->
 			<Grid.ColumnDefinitions>
 				<ColumnDefinition Width="{Binding TreeColumnWidth, Mode=TwoWay}"/>
-				<ColumnDefinition Width="0"/>
+				<ColumnDefinition Width="Auto"/>
 				<ColumnDefinition Width="*"/>
 			</Grid.ColumnDefinitions>
 			<!-- The game's filesystem tree. Bound to a collection of FileSystemEntryNodes.

--- a/BundleManager/Views/ObjectList.axaml
+++ b/BundleManager/Views/ObjectList.axaml
@@ -16,6 +16,7 @@
 		<Grid ColumnDefinitions="Auto, Auto"
 			  HorizontalAlignment="Left"
 			  VerticalAlignment="Top"
+			  Margin="2"
 			  ZIndex="1">
 			<Button Content="&#x2190;"
 					Command="{Binding CloseViewCommand}"

--- a/BundleManager/Views/ObjectList.axaml
+++ b/BundleManager/Views/ObjectList.axaml
@@ -14,24 +14,21 @@
 	
 	<Grid>
 		<Grid ColumnDefinitions="Auto, Auto"
-			  HorizontalAlignment="Right"
+			  HorizontalAlignment="Left"
+			  VerticalAlignment="Top"
 			  ZIndex="1">
+			<Button Content="&#x2190;"
+					Command="{Binding CloseViewCommand}"
+					IsEnabled="{Binding IsChild}"
+					FontSize="16"
+					Padding="6,4,6,4"
+					Grid.Column="0"/>
 			<Button Content="+"
 					Command="{Binding AddItemCommand}"
 					IsEnabled="{Binding CanAddItems}"
 					IsVisible="{Binding DisplayAddRemoveItems}"
 					FontSize="16"
 					Padding="8,4,8,4"
-					HorizontalAlignment="Right"
-					VerticalAlignment="Top"
-					Grid.Column="0"/>
-			<Button Content="X"
-					Command="{Binding CloseViewCommand}"
-					IsEnabled="{Binding IsChild}"
-					FontSize="16"
-					Padding="8,4,8,4"
-					HorizontalAlignment="Right"
-					VerticalAlignment="Top"
 					Grid.Column="1"/>
 		</Grid>
 		<DataGrid ItemsSource="{Binding Objects}"

--- a/BundleManager/Views/ObjectList.axaml
+++ b/BundleManager/Views/ObjectList.axaml
@@ -43,6 +43,14 @@
 										 PassEventArgsToCommand="True"/>
 				</EventTriggerBehavior>
 			</Interaction.Behaviors>
+			<DataGrid.Styles>
+				<Style Selector="DataGrid /template/ ScrollBar#PART_VerticalScrollbar">
+					<Setter Property="AllowAutoHide" Value="False"/>
+				</Style>
+				<Style Selector="DataGrid /template/ ScrollBar#PART_HorizontalScrollbar">
+					<Setter Property="AllowAutoHide" Value="False"/>
+				</Style>
+			</DataGrid.Styles>
 		</DataGrid>
 	</Grid>
 	

--- a/BundleManager/Views/PropertyGrid.axaml
+++ b/BundleManager/Views/PropertyGrid.axaml
@@ -21,7 +21,7 @@
 				HorizontalAlignment="Left"
 				VerticalAlignment="Top"
 				ZIndex="1"/>
-		<ScrollViewer>
+		<ScrollViewer AllowAutoHide="False">
 			<ItemsControl ItemsSource="{Binding Properties}"
 						  Grid.IsSharedSizeScope="True">
 				<ItemsControl.ItemTemplate>

--- a/BundleManager/Views/PropertyGrid.axaml
+++ b/BundleManager/Views/PropertyGrid.axaml
@@ -12,16 +12,17 @@
 		<datatemplates:PropertyTemplateSelector x:Key="PropertyTemplateSelector"/>
 	</UserControl.Resources>
 	
-	<Grid>
+	<Grid RowDefinitions="Auto, *">
 		<Button Content="&#x2190;"
 				Command="{Binding CloseViewCommand}"
 				IsEnabled="{Binding IsChild}"
 				FontSize="16"
-				Padding="8,4,8,4"
+				Padding="6,4,6,4"
 				HorizontalAlignment="Left"
 				VerticalAlignment="Top"
-				ZIndex="1"/>
-		<ScrollViewer AllowAutoHide="False">
+				Grid.Row="0"/>
+		<ScrollViewer AllowAutoHide="False"
+					  Grid.Row="1">
 			<ItemsControl ItemsSource="{Binding Properties}"
 						  Grid.IsSharedSizeScope="True">
 				<ItemsControl.ItemTemplate>

--- a/BundleManager/Views/PropertyGrid.axaml
+++ b/BundleManager/Views/PropertyGrid.axaml
@@ -13,12 +13,12 @@
 	</UserControl.Resources>
 	
 	<Grid>
-		<Button Content="X"
+		<Button Content="&#x2190;"
 				Command="{Binding CloseViewCommand}"
 				IsEnabled="{Binding IsChild}"
 				FontSize="16"
 				Padding="8,4,8,4"
-				HorizontalAlignment="Right"
+				HorizontalAlignment="Left"
 				VerticalAlignment="Top"
 				ZIndex="1"/>
 		<ScrollViewer>

--- a/BundleManager/Views/SimpleList.axaml
+++ b/BundleManager/Views/SimpleList.axaml
@@ -14,24 +14,21 @@
 
 	<Grid>
 		<Grid ColumnDefinitions="Auto, Auto"
-			  HorizontalAlignment="Right"
+			  HorizontalAlignment="Left"
+			  VerticalAlignment="Top"
 			  ZIndex="1">
+			<Button Content="&#x2190;"
+					Command="{Binding CloseViewCommand}"
+					IsEnabled="{Binding IsChild}"
+					FontSize="16"
+					Padding="6,4,6,4"
+					Grid.Column="0"/>
 			<Button Content="+"
 					Command="{Binding AddItemCommand}"
 					IsEnabled="{Binding CanAddItems}"
 					IsVisible="{Binding DisplayAddRemoveItems}"
 					FontSize="16"
 					Padding="8,4,8,4"
-					HorizontalAlignment="Right"
-					VerticalAlignment="Top"
-					Grid.Column="0"/>
-			<Button Content="X"
-					Command="{Binding CloseViewCommand}"
-					IsEnabled="{Binding IsChild}"
-					FontSize="16"
-					Padding="8,4,8,4"
-					HorizontalAlignment="Right"
-					VerticalAlignment="Top"
 					Grid.Column="1"/>
 		</Grid>
 		<ScrollViewer>

--- a/BundleManager/Views/SimpleList.axaml
+++ b/BundleManager/Views/SimpleList.axaml
@@ -31,7 +31,7 @@
 					Padding="8,4,8,4"
 					Grid.Column="1"/>
 		</Grid>
-		<ScrollViewer>
+		<ScrollViewer AllowAutoHide="False">
 			<ItemsControl ItemsSource="{Binding SimpleObjects}"
 					 Grid.IsSharedSizeScope="True">
 				<ItemsControl.ItemTemplate>

--- a/BundleManager/Views/SimpleList.axaml
+++ b/BundleManager/Views/SimpleList.axaml
@@ -12,11 +12,11 @@
 		<datatemplates:SimpleTemplateSelector x:Key="SimpleTemplateSelector"/>
 	</UserControl.Resources>
 
-	<Grid>
+	<Grid RowDefinitions="Auto, *">
 		<Grid ColumnDefinitions="Auto, Auto"
 			  HorizontalAlignment="Left"
 			  VerticalAlignment="Top"
-			  ZIndex="1">
+			  Grid.Row="0">
 			<Button Content="&#x2190;"
 					Command="{Binding CloseViewCommand}"
 					IsEnabled="{Binding IsChild}"
@@ -31,7 +31,8 @@
 					Padding="8,4,8,4"
 					Grid.Column="1"/>
 		</Grid>
-		<ScrollViewer AllowAutoHide="False">
+		<ScrollViewer AllowAutoHide="False"
+					  Grid.Row="1">
 			<ItemsControl ItemsSource="{Binding SimpleObjects}"
 					 Grid.IsSharedSizeScope="True">
 				<ItemsControl.ItemTemplate>


### PR DESCRIPTION
- The universal editor's close button is now a back button, and the buttons are now in the top left. Except in the object list, these buttons now have their own grid row.
- Scrollbars will no longer be automatically hidden after a brief period and are instead always shown.
- The MainWindow's GridSplitter's column width is now automatic instead of zero. This prevents the shadow in the middle seen previously.
- A folder creation crash caused by leftover debugging code has been resolved.