### PR TITLE
Add HPR Xbox One executable name

### DIFF
--- a/BundleManager/ViewModels/OptionsWindow.cs
+++ b/BundleManager/ViewModels/OptionsWindow.cs
@@ -249,9 +249,8 @@ public partial class OptionsWindow : ObservableObject
 						executableName = "Burnout_External_Xbox_One.exe";
 						break;
 					case Game.HotPursuitRemastered:
-						// TODO: Dump game and get executable name
-						WarningText = string.Empty;
-						return;
+						executableName = "Alaska_Unity_External.exe";
+						break;
 				}
 			}
 			foreach (FileInfo fileInfo in dirInfo.GetFiles())


### PR DESCRIPTION
Adds the executable name for warning text. This was the only game missing it.