### PR TITLE
Texture pipeline & importing improvements

### DIFF
--- a/BaseHandlers/TextureState.cs
+++ b/BaseHandlers/TextureState.cs
@@ -45,10 +45,7 @@ namespace BaseHandlers
 
                     if (descEntry1 != null && descEntry1.Type == EntryType.Texture)
                     {
-                        if (entry.Console)
-                            result.Texture = GameImage.GetImagePS3(descEntry1.EntryBlocks[0].Data, descEntry1.EntryBlocks[1].Data);
-                        else
-                            result.Texture = GameImage.GetImage(descEntry1.EntryBlocks[0].Data, descEntry1.EntryBlocks[1].Data);
+                        result.Texture = GameImage.GetImage(descEntry1.EntryBlocks[0].Data, descEntry1.EntryBlocks[1].Data);
 
                         if (result.Texture != null)
                             TextureCache.AddToCache(id, result.Texture);

--- a/BundleManager/EntryEditor.Designer.cs
+++ b/BundleManager/EntryEditor.Designer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace BundleManager
 {
@@ -53,6 +53,7 @@ namespace BundleManager
             exportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             importToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             stsMain = new System.Windows.Forms.StatusStrip();
+            imageStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
             pbMain = new System.Windows.Forms.ProgressBar();
             pboImage = new System.Windows.Forms.PictureBox();
             tabList.SuspendLayout();
@@ -60,6 +61,7 @@ namespace BundleManager
             tabHeader.SuspendLayout();
             tabBody.SuspendLayout();
             mnuBar.SuspendLayout();
+            stsMain.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)pboImage).BeginInit();
             SuspendLayout();
             // 
@@ -93,7 +95,7 @@ namespace BundleManager
             txtInfo.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
             txtInfo.BackColor = System.Drawing.SystemColors.ControlLightLight;
             txtInfo.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            txtInfo.Font = new System.Drawing.Font("Consolas", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            txtInfo.Font = new System.Drawing.Font("Consolas", 9.75F);
             txtInfo.Location = new System.Drawing.Point(9, 3);
             txtInfo.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             txtInfo.Multiline = true;
@@ -110,7 +112,7 @@ namespace BundleManager
             tabHeader.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             tabHeader.Name = "tabHeader";
             tabHeader.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            tabHeader.Size = new System.Drawing.Size(720, 455);
+            tabHeader.Size = new System.Drawing.Size(720, 459);
             tabHeader.TabIndex = 0;
             tabHeader.Text = "Header";
             tabHeader.UseVisualStyleBackColor = true;
@@ -121,12 +123,12 @@ namespace BundleManager
             hexData.BackColor = System.Drawing.Color.White;
             hexData.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             hexData.Dock = System.Windows.Forms.DockStyle.Fill;
-            hexData.Font = new System.Drawing.Font("Courier New", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            hexData.Font = new System.Drawing.Font("Courier New", 10F);
             hexData.HexData = null;
             hexData.Location = new System.Drawing.Point(4, 3);
             hexData.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             hexData.Name = "hexData";
-            hexData.Size = new System.Drawing.Size(712, 449);
+            hexData.Size = new System.Drawing.Size(712, 453);
             hexData.TabIndex = 0;
             // 
             // tabBody
@@ -136,7 +138,7 @@ namespace BundleManager
             tabBody.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             tabBody.Name = "tabBody";
             tabBody.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            tabBody.Size = new System.Drawing.Size(720, 455);
+            tabBody.Size = new System.Drawing.Size(720, 459);
             tabBody.TabIndex = 2;
             tabBody.Text = "Body";
             tabBody.UseVisualStyleBackColor = true;
@@ -147,18 +149,18 @@ namespace BundleManager
             hexExtraData.BackColor = System.Drawing.Color.White;
             hexExtraData.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             hexExtraData.Dock = System.Windows.Forms.DockStyle.Fill;
-            hexExtraData.Font = new System.Drawing.Font("Courier New", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            hexExtraData.Font = new System.Drawing.Font("Courier New", 10F);
             hexExtraData.HexData = null;
             hexExtraData.Location = new System.Drawing.Point(4, 3);
             hexExtraData.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             hexExtraData.Name = "hexExtraData";
-            hexExtraData.Size = new System.Drawing.Size(712, 449);
+            hexExtraData.Size = new System.Drawing.Size(712, 453);
             hexExtraData.TabIndex = 0;
             // 
             // lblLoading
             // 
             lblLoading.Dock = System.Windows.Forms.DockStyle.Fill;
-            lblLoading.Font = new System.Drawing.Font("Courier New", 36F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            lblLoading.Font = new System.Drawing.Font("Courier New", 36F, System.Drawing.FontStyle.Bold);
             lblLoading.Location = new System.Drawing.Point(0, 0);
             lblLoading.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             lblLoading.Name = "lblLoading";
@@ -187,33 +189,33 @@ namespace BundleManager
             // importHeaderToolStripMenuItem
             // 
             importHeaderToolStripMenuItem.Name = "importHeaderToolStripMenuItem";
-            importHeaderToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            importHeaderToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
             importHeaderToolStripMenuItem.Text = "Import Header";
             importHeaderToolStripMenuItem.Click += importDataToolStripMenuItem_Click;
             // 
             // exportHeaderToolStripMenuItem
             // 
             exportHeaderToolStripMenuItem.Name = "exportHeaderToolStripMenuItem";
-            exportHeaderToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            exportHeaderToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
             exportHeaderToolStripMenuItem.Text = "Export Header";
             exportHeaderToolStripMenuItem.Click += exportDataToolStripMenuItem_Click;
             // 
             // toolStripMenuItem1
             // 
             toolStripMenuItem1.Name = "toolStripMenuItem1";
-            toolStripMenuItem1.Size = new System.Drawing.Size(177, 6);
+            toolStripMenuItem1.Size = new System.Drawing.Size(148, 6);
             // 
             // importBodyToolStripMenuItem
             // 
             importBodyToolStripMenuItem.Name = "importBodyToolStripMenuItem";
-            importBodyToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            importBodyToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
             importBodyToolStripMenuItem.Text = "Import Body";
             importBodyToolStripMenuItem.Click += importExtraToolStripMenuItem_Click;
             // 
             // exportBodyToolStripMenuItem
             // 
             exportBodyToolStripMenuItem.Name = "exportBodyToolStripMenuItem";
-            exportBodyToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            exportBodyToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
             exportBodyToolStripMenuItem.Text = "Export Body";
             exportBodyToolStripMenuItem.Click += exportExtraToolStripMenuItem_Click;
             // 
@@ -227,14 +229,14 @@ namespace BundleManager
             // editHashToolStripMenuItem
             // 
             editHashToolStripMenuItem.Name = "editHashToolStripMenuItem";
-            editHashToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            editHashToolStripMenuItem.Size = new System.Drawing.Size(176, 22);
             editHashToolStripMenuItem.Text = "Edit ID";
             editHashToolStripMenuItem.Click += editId_Click;
             // 
             // calcLookupHashToolStripMenuItem
             // 
             calcLookupHashToolStripMenuItem.Name = "calcLookupHashToolStripMenuItem";
-            calcLookupHashToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            calcLookupHashToolStripMenuItem.Size = new System.Drawing.Size(176, 22);
             calcLookupHashToolStripMenuItem.Text = "Calc Lookup8 Hash";
             calcLookupHashToolStripMenuItem.Click += calcLookup8_Click;
             // 
@@ -261,11 +263,19 @@ namespace BundleManager
             // 
             // stsMain
             // 
+            stsMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { imageStatusLabel });
             stsMain.Location = new System.Drawing.Point(0, 487);
             stsMain.Name = "stsMain";
             stsMain.Padding = new System.Windows.Forms.Padding(1, 0, 16, 0);
             stsMain.Size = new System.Drawing.Size(728, 22);
             stsMain.TabIndex = 7;
+            // 
+            // imageStatusLabel
+            // 
+            imageStatusLabel.Name = "imageStatusLabel";
+            imageStatusLabel.Size = new System.Drawing.Size(83, 17);
+            imageStatusLabel.Text = "Compression: ";
+            imageStatusLabel.Visible = false;
             // 
             // pbMain
             // 
@@ -317,6 +327,8 @@ namespace BundleManager
             tabBody.ResumeLayout(false);
             mnuBar.ResumeLayout(false);
             mnuBar.PerformLayout();
+            stsMain.ResumeLayout(false);
+            stsMain.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)pboImage).EndInit();
             ResumeLayout(false);
             PerformLayout();
@@ -349,5 +361,6 @@ namespace BundleManager
         private System.Windows.Forms.PictureBox pboImage;
         private System.Windows.Forms.TabPage tabInfo;
         private System.Windows.Forms.TextBox txtInfo;
+        private System.Windows.Forms.ToolStripStatusLabel imageStatusLabel;
     }
 }

--- a/BundleManager/EntryEditor.cs
+++ b/BundleManager/EntryEditor.cs
@@ -506,7 +506,7 @@ namespace BundleManager
         private void importToolStripMenuItem_Click(object sender, EventArgs e)
         {
             OpenFileDialog ofd = new OpenFileDialog();
-            ofd.Filter = "Image Files(*.bmp;*.gif;*.jpg;*.png;*.tif;*.tga;*.webp)|*.bmp;*.gif;*.jpg;*.png;*.tif;*.tga;*.webp|All files (*.*)|*.*";
+            ofd.Filter = "Image Files(*.dds,*.bmp;*.gif;*.jpg;*.png;*.tif;*.tga;*.webp)|*.dds;*.bmp;*.gif;*.jpg;*.png;*.tif;*.tga;*.webp|All files (*.*)|*.*";
             ofd.FileOk += Ofd_FileOk;
             ofd.ShowDialog(this);
         }
@@ -525,7 +525,6 @@ namespace BundleManager
         private void ImportImage(string path)
         {
             _entry.Dirty = true;
-            Image newImage = Image.FromFile(path);
 
             ImageVisible = false;
             TabsVisible = false;
@@ -534,7 +533,7 @@ namespace BundleManager
 
             ImageHeader header = GameImage.GetImageHeader(_entry.EntryBlocks[0].Data);
 
-            ImageInfo info = GameImage.SetImage(path, newImage.Width, newImage.Height, header.CompressionType, header.Platform);
+            ImageInfo info = GameImage.SetImage(path, header.CompressionType, header.Platform);
 
             Entry.EntryBlocks[0].Data = info.Header;
             Entry.EntryBlocks[1].Data = info.Data;

--- a/BundleManager/EntryEditor.cs
+++ b/BundleManager/EntryEditor.cs
@@ -463,10 +463,7 @@ namespace BundleManager
             }
             else if (_entry.Type == EntryType.Texture)
             {
-                if (_entry.Console)
-                    Image = GameImage.GetImagePS3(_entry.EntryBlocks[0].Data, _entry.EntryBlocks[1].Data);
-                else
-                    Image = GameImage.GetImage(_entry.EntryBlocks[0].Data, _entry.EntryBlocks[1].Data);
+                Image = GameImage.GetImage(_entry.EntryBlocks[0].Data, _entry.EntryBlocks[1].Data);
 
                 ImageVisible = Image != null;
 
@@ -537,7 +534,7 @@ namespace BundleManager
 
             ImageHeader header = GameImage.GetImageHeader(_entry.EntryBlocks[0].Data);
 
-            ImageInfo info = GameImage.SetImage(path, newImage.Width, newImage.Height, header.CompressionType);
+            ImageInfo info = GameImage.SetImage(path, newImage.Width, newImage.Height, header.CompressionType, header.Platform);
 
             Entry.EntryBlocks[0].Data = info.Header;
             Entry.EntryBlocks[1].Data = info.Data;

--- a/BundleManager/EntryEditor.cs
+++ b/BundleManager/EntryEditor.cs
@@ -12,7 +12,6 @@ using BundleFormat;
 using BundleUtilities;
 using BurnoutImage;
 using LangEditor;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace BundleManager
 {

--- a/BundleManager/EntryEditor.cs
+++ b/BundleManager/EntryEditor.cs
@@ -12,6 +12,7 @@ using BundleFormat;
 using BundleUtilities;
 using BurnoutImage;
 using LangEditor;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace BundleManager
 {
@@ -72,6 +73,7 @@ namespace BundleManager
             ImageMenuVisible = false;
             BinaryMenuVisible = false;
             ImageVisible = false;
+            ImageStatusPanelVisible = false;
             TabsVisible = false;
 
             //txtData.MaxLength = int.MaxValue;
@@ -290,6 +292,40 @@ namespace BundleManager
             }
         }
 
+        private bool ImageStatusPanelVisible
+        {
+            get
+            {
+                if (mnuBar.InvokeRequired)
+                {
+                    GetBool method = () =>
+                    {
+                        return imageStatusLabel.Visible;
+                    };
+                    return (bool)Invoke(method);
+                }
+                else
+                {
+                    return imageStatusLabel.Visible;
+                }
+            }
+            set
+            {
+                if (mnuBar.InvokeRequired)
+                {
+                    SetBool method = (bool enabled) =>
+                    {
+                        imageStatusLabel.Visible = enabled;
+                    };
+                    Invoke(method, value);
+                }
+                else
+                {
+                    imageStatusLabel.Visible = value;
+                }
+            }
+        }
+
         private bool ImageMenuVisible
         {
             get
@@ -470,7 +506,17 @@ namespace BundleManager
             }
             TabsVisible = !ImageVisible;
             ImageMenuVisible = ImageVisible;
+            ImageStatusPanelVisible = ImageVisible;
             BinaryMenuVisible = TabsVisible;
+
+            if (ImageStatusPanelVisible)
+            {
+                ImageHeader header = GameImage.GetImageHeader(_entry.EntryBlocks[0].Data);
+                imageStatusLabel.Text = 
+                    $"Platform: {header.Platform}    " +
+                    $"Size: {header.Width}x{header.Height}    " +
+                    $"Format: {header.CompressionType}";
+            }
 
             if (TabsVisible)
             {

--- a/BundleManager/EntryEditor.resx
+++ b/BundleManager/EntryEditor.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">

--- a/BurnoutImage/GameImage.cs
+++ b/BurnoutImage/GameImage.cs
@@ -59,7 +59,9 @@ namespace BurnoutImage
                 width = br.ReadInt32();
 
                 fs.Seek(0x1C, SeekOrigin.Begin);
-                numMips = br.ReadInt32() + 1;
+                numMips = br.ReadInt32();
+                if (numMips <= 0)
+                    numMips = 1;
 
                 fs.Seek(0x4C, SeekOrigin.Begin);
                 uint pfSize = br.ReadUInt32();

--- a/BurnoutImage/GameImage.cs
+++ b/BurnoutImage/GameImage.cs
@@ -226,7 +226,7 @@ namespace BurnoutImage
                     // DXGI_Format
                     CompressionType type = br.ReadUInt32() switch
                     {
-                        0x00000015  => CompressionType.BGRA,
+                        0x00000057  => CompressionType.BGRA,
                         0x0000001C  => CompressionType.RGBA,
                         0x000000FF  => CompressionType.ARGB,
                         0x00000047  => CompressionType.DXT1,

--- a/BurnoutImage/GameImage.cs
+++ b/BurnoutImage/GameImage.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Windows.Forms;
 using BCnEncoder.Shared;
 using BundleUtilities;
-using Microsoft.Toolkit.HighPerformance;
 
 namespace BurnoutImage
 {
@@ -27,7 +26,7 @@ namespace BurnoutImage
         public readonly CompressionType CompressionType;
         public readonly int Width, Height;
 
-        public ImageHeader(CompressionType compression, int width, int height, PlatformType platform = PlatformType.Remaster)
+        public ImageHeader(CompressionType compression, int width, int height, PlatformType platform = PlatformType.Remastered)
         {
             CompressionType = compression;
             Width = width;
@@ -38,7 +37,7 @@ namespace BurnoutImage
 
     public static class GameImage
     {
-        public static ImageInfo SetImage(string path, CompressionType compression, PlatformType platform = PlatformType.Remaster)
+        public static ImageInfo SetImage(string path, CompressionType compression, PlatformType platform = PlatformType.Remastered)
         {
             byte[] data;
             int width = 0, height = 0, numMips = 1;
@@ -137,7 +136,7 @@ namespace BurnoutImage
             MemoryStream msx = new();
             BinaryWriter2 bw = new(msx);
 
-            if (platform == PlatformType.Remaster)
+            if (platform == PlatformType.Remastered)
             {
                 // Remastered Texture header: https://burnout.wiki/wiki/Texture/Remastered
                 bw.Write(0); // Texture interface pointer
@@ -245,7 +244,7 @@ namespace BurnoutImage
 
                     br.Close();
 
-                    return new ImageHeader(type, width, height, PlatformType.Remaster);
+                    return new ImageHeader(type, width, height, PlatformType.Remastered);
                 }
                 else if (data.Length == 0x20) // OLD PC
                 {
@@ -394,7 +393,7 @@ namespace BurnoutImage
 
     public enum PlatformType
     {
-        Remaster,
+        Remastered,
         PC,
         PS3,
         X360

--- a/BurnoutImage/GameImage.cs
+++ b/BurnoutImage/GameImage.cs
@@ -292,7 +292,7 @@ namespace BurnoutImage
                     {
                         CompressionType.DXT1 => ImageUtil.DecompressImage(extraData, header.Width, header.Height, CompressionFormat.Bc1),
                         CompressionType.DXT5 => ImageUtil.DecompressImage(extraData, header.Width, header.Height, CompressionFormat.Bc3),
-                        _ => throw new NotImplementedException()
+                        _ => extraData
                     };
 
                     DirectBitmap bitmap = new(header.Width, header.Height);

--- a/BurnoutImage/GameImage.cs
+++ b/BurnoutImage/GameImage.cs
@@ -204,12 +204,12 @@ namespace BurnoutImage
                 MemoryStream ms = new(data);
                 BinaryReader2 br = new(ms);
 
-                PlatformType type = DetectPlatform(data);
-                if (type == PlatformType.X360)
+                PlatformType platform = DetectPlatform(data);
+                if (platform == PlatformType.X360)
                 {
                     throw new Exception("Xbox 360 textures are not supported yet.");
                 }
-                else if (type == PlatformType.Remastered)
+                else if (platform == PlatformType.Remastered)
                 {
                     br.BaseStream.Seek(0x00, SeekOrigin.Begin);
 
@@ -243,7 +243,7 @@ namespace BurnoutImage
 
                     return new ImageHeader(type, width, height, PlatformType.Remastered);
                 }
-                else if (type == PlatformType.PC)
+                else if (platform == PlatformType.PC)
                 {
                     br.BaseStream.Seek(0x10, SeekOrigin.Begin);
 
@@ -264,7 +264,7 @@ namespace BurnoutImage
 
                     return new ImageHeader(type, width, height, PlatformType.PC);
                 }
-                else if (type == PlatformType.PS3) // PS3
+                else if (platform == PlatformType.PS3) // PS3
                 {
                     br.BaseStream.Seek(0x00, SeekOrigin.Begin);
 

--- a/BurnoutImage/GameImage.cs
+++ b/BurnoutImage/GameImage.cs
@@ -60,9 +60,16 @@ namespace BurnoutImage
                 width = br.ReadInt32();
 
                 fs.Seek(0x1C, SeekOrigin.Begin);
-                numMips = br.ReadInt32();
-                if (numMips <= 0)
-                    numMips = 1;
+                numMips = br.ReadInt32() + 1;
+
+                fs.Seek(0x54, SeekOrigin.Begin);
+                compression = br.ReadInt32() switch
+                {
+                    0x31545844 => CompressionType.DXT1, // "DXT1"
+                    0x35545844 => CompressionType.DXT5, // "DXT5"
+                    0x00000000 => CompressionType.RGBA,
+                    _ => CompressionType.RGBA
+                };
 
                 const int ddsHeaderSize = 0x80;
                 fs.Seek(ddsHeaderSize, SeekOrigin.Begin);

--- a/BurnoutImage/ImageUtil.cs
+++ b/BurnoutImage/ImageUtil.cs
@@ -1,3 +1,4 @@
+using System;
 using BCnEncoder.Shared;
 
 namespace BurnoutImage
@@ -12,6 +13,66 @@ namespace BurnoutImage
         public static byte[] CompressImage(string path, CompressionFormat compression)
         {
             return CompressionTools.CompressTexture(path, compression);
+        }
+
+        public static CompressionType DetectDdsFormat(
+            uint pfFlags,
+            uint pfFourCC,
+            uint pfRGBBitCount,
+            uint pfRBitMask,
+            uint pfGBitMask,
+            uint pfBBitMask,
+            uint pfABitMask)
+        {
+            const uint DDPF_ALPHAPIXELS = 0x00000001;
+            const uint DDPF_FOURCC = 0x00000004;
+            const uint DDPF_RGB = 0x00000040;
+
+            if ((pfFlags & DDPF_FOURCC) != 0)
+            {
+                switch (pfFourCC)
+                {
+                    case 0x31545844u:
+                        return CompressionType.DXT1;
+                    case 0x35545844u:
+                        return CompressionType.DXT5;
+                    case 0x00000015u:
+                        return CompressionType.BGRA;
+                    case 0x0000001Cu:
+                        return CompressionType.RGBA;
+                    case 0x000000FFu:
+                        return CompressionType.ARGB;
+                    case 0x30315844u:
+                        throw new NotSupportedException("DX10 DDS files are not supported by this reader.");
+                }
+
+                return CompressionType.UNKNOWN;
+            }
+
+            if ((pfFlags & DDPF_RGB) != 0 && pfRGBBitCount == 32)
+            {
+                if (pfRBitMask == 0x00FF0000u &&
+                    pfGBitMask == 0x0000FF00u &&
+                    pfBBitMask == 0x000000FFu)
+                {
+                    if (pfABitMask == 0xFF000000u)
+                        return CompressionType.BGRA;
+                    if ((pfFlags & DDPF_ALPHAPIXELS) == 0 && pfABitMask == 0)
+                        return CompressionType.BGRA;
+                }
+
+                if (pfRBitMask == 0x000000FFu &&
+                    pfGBitMask == 0x0000FF00u &&
+                    pfBBitMask == 0x00FF0000u)
+                {
+                    if (pfABitMask == 0xFF000000u)
+                        return CompressionType.RGBA;
+                    if ((pfFlags & DDPF_ALPHAPIXELS) == 0 && pfABitMask == 0)
+                        return CompressionType.RGBA;
+                }
+            }
+
+            return CompressionType.UNKNOWN;
         }
     }
 }

--- a/PVSFormat/PVS.cs
+++ b/PVSFormat/PVS.cs
@@ -290,10 +290,7 @@ namespace PVSFormat
 
             if (descEntry1 != null && descEntry1.Type == EntryType.Texture)
             {
-                if (archive.Console)
-                    image = GameImage.GetImagePS3(descEntry1.EntryBlocks[0].Data, descEntry1.EntryBlocks[1].Data);
-                else
-                    image = GameImage.GetImage(descEntry1.EntryBlocks[0].Data, descEntry1.EntryBlocks[1].Data);
+                image = GameImage.GetImage(descEntry1.EntryBlocks[0].Data, descEntry1.EntryBlocks[1].Data);
 
                 if (image != null)
                     TextureCache.AddToCache(id, image);


### PR DESCRIPTION
This PR is an overall improvement to the way that Bundle Manager handles game textures, including:

- Adding platform detection (this fixes the ability to also replace textures in the original PC version, along with laying the scaffolding for 360 and PS3 support)
- adding the ability to import DDS files (including their mipmaps, unlike other image formats)
- Cleaning up and modernizing a majority of the GameImage code
- Displaying texture information in the preview UI, including size and format