### PR TITLE
Target .NET 10

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,7 @@ charset = utf-8
 indent_style = space
 indent_size = 4
 dotnet_diagnostic.CA1416.severity = none
+
+[*.csproj]
+indent_style = space
+indent_size = 2

--- a/BaseHandlers/BaseHandlers.csproj
+++ b/BaseHandlers/BaseHandlers.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>

--- a/BaseHandlers/InstanceListEditor.cs
+++ b/BaseHandlers/InstanceListEditor.cs
@@ -6,6 +6,7 @@ using ModelViewer.SceneData;
 using PluginAPI;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Threading;
 using System.Windows.Forms;
 
@@ -18,6 +19,7 @@ namespace BaseHandlers
 
         private InstanceList _instanceList;
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public InstanceList InstanceList
         {
             get => _instanceList;

--- a/BaseHandlers/StreetDataEditor.cs
+++ b/BaseHandlers/StreetDataEditor.cs
@@ -1,11 +1,12 @@
+using PluginAPI;
 using System;
 using System.Collections;
+using System.ComponentModel;
 using System.Globalization;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Windows.Forms;
-using PluginAPI;
 
 namespace BaseHandlers
 {
@@ -14,6 +15,7 @@ namespace BaseHandlers
         public event Notify EditEvent;
 
         private StreetData _model;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public StreetData Model
         {
             get => _model;

--- a/BaseHandlers/TriggerDataEditor.cs
+++ b/BaseHandlers/TriggerDataEditor.cs
@@ -1,6 +1,7 @@
-using System;
-using System.Windows.Forms;
 using PluginAPI;
+using System;
+using System.ComponentModel;
+using System.Windows.Forms;
 
 namespace BaseHandlers
 {
@@ -10,6 +11,7 @@ namespace BaseHandlers
         public event Notify EditEvent;
 
         private TriggerData _trigger;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public TriggerData trigger
         {
             get => _trigger;

--- a/BundleFormat/BundleFormat.csproj
+++ b/BundleFormat/BundleFormat.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>

--- a/BundleManager/BundleManager.csproj
+++ b/BundleManager/BundleManager.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
@@ -18,18 +18,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup>
     <StartupObject>BundleManager.Program</StartupObject>
-  </PropertyGroup>
-  <PropertyGroup>
     <ApplicationIcon>icon.ico</ApplicationIcon>
-  </PropertyGroup>
-  <PropertyGroup>
     <ApplicationManifest>App.manifest</ApplicationManifest>
-  </PropertyGroup>
-  <PropertyGroup>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
@@ -58,7 +49,7 @@
     <ProjectReference Include="..\PluginAPI\PluginAPI.csproj" />
     <ProjectReference Include="..\PluginSystem\PluginSystem.csproj" />
   </ItemGroup>
-  <Target Name="Plugins" BeforeTargets="Build">
+  <Target Name="Plugins" AfterTargets="Build" Condition="'$(TargetFramework)' != ''">
     <ItemGroup>
       <PluginFiles Include="..\BaseHandlers\bin\$(Configuration)\$(TargetFramework)\BaseHandlers.dll;
                             ..\BaseHandlers\bin\$(Configuration)\$(TargetFramework)\BaseHandlers.pdb;
@@ -83,10 +74,10 @@
           DestinationFolder="$(OutputPath)plugins"
           SkipUnchangedFiles="true" />
   </Target>
-  <ItemGroup>
-    <ShaderFiles Include="$(SolutionDir)resources\Shaders\**\*.*" />
-  </ItemGroup>
-  <Target Name="Shaders" AfterTargets="Build">
+  <Target Name="Shaders" AfterTargets="Build" Condition="'$(TargetFramework)' != ''">
+    <ItemGroup>
+      <ShaderFiles Include="$(SolutionDir)resources\Shaders\**\*.*" />
+    </ItemGroup>
     <Copy SourceFiles="@(ShaderFiles)"
           DestinationFolder="$(OutputPath)Shaders"
           SkipUnchangedFiles="true" />

--- a/BundleManager/EntryEditor.cs
+++ b/BundleManager/EntryEditor.cs
@@ -21,6 +21,7 @@ namespace BundleManager
         private delegate void SetEntry(BundleEntry entry);
 
         private BundleEntry _entry;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public BundleEntry Entry
         {
             get
@@ -57,8 +58,7 @@ namespace BundleManager
             }
         }
 
-
-
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public bool ForceHex
         {
             get;

--- a/BundleManager/MainForm.cs
+++ b/BundleManager/MainForm.cs
@@ -18,6 +18,7 @@ namespace BundleManager
         #region Variables and Properties
 
         private bool _subForm;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public bool SubForm
         {
             get { return _subForm; }

--- a/BundleManager/VertexSizePicker.cs
+++ b/BundleManager/VertexSizePicker.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Windows.Forms;
 
 namespace BundleManager
@@ -20,6 +21,7 @@ namespace BundleManager
         }
 
         private List<int> _vertexSizeList;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public List<int> VertexSizeList
         {
             get { return _vertexSizeList; }

--- a/BundleUtilities/BundleUtilities.csproj
+++ b/BundleUtilities/BundleUtilities.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>

--- a/BundleUtilities/LoadingDialog.cs
+++ b/BundleUtilities/LoadingDialog.cs
@@ -1,5 +1,6 @@
 using BundleUtilities;
 using System;
+using System.ComponentModel;
 using System.Windows.Forms;
 
 namespace BundleUtilities
@@ -12,6 +13,7 @@ namespace BundleUtilities
         private delegate object GetObject();
         private delegate void SetObject(object obj);
         private object _value;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public object Value
         {
             get
@@ -46,14 +48,17 @@ namespace BundleUtilities
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public bool IsDone { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public string Status
         {
             get => lblStatus.Text;
             set => lblStatus.Text = value;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public int Progress
         {
             get => pboMain.Value;

--- a/BurnoutImage/BurnoutImage.csproj
+++ b/BurnoutImage/BurnoutImage.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\BundleUtilities\BundleUtilities.csproj" />

--- a/BurnoutImage/CompressionTools.cs
+++ b/BurnoutImage/CompressionTools.cs
@@ -30,7 +30,7 @@ namespace BurnoutImage
         {
             BcDecoder decoder = new BcDecoder();
             Image<Rgba32> image = decoder.DecodeRawToImageRgba32(source, width, height, compression);
-            byte[] data = new byte[width * height * Unsafe.SizeOf<Rgba32>()];
+            byte[] data = new byte[width * height * 4];
             image.CopyPixelDataTo(data);
             return data;
         }

--- a/ComponentTester/ComponentTester.csproj
+++ b/ComponentTester/ComponentTester.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>

--- a/HexEditor/HexEditor.csproj
+++ b/HexEditor/HexEditor.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>

--- a/HexEditor/HexView.cs
+++ b/HexEditor/HexView.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Drawing;
 using System.Text;
 using System.Windows.Forms;
@@ -8,6 +9,7 @@ namespace HexEditor
     public class HexView : UserControl
     {
         private byte[] _hexData;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public byte[] HexData
         {
             get

--- a/IconLibrary/IconLibrary.csproj
+++ b/IconLibrary/IconLibrary.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>

--- a/LangEditor/LangEdit.cs
+++ b/LangEditor/LangEdit.cs
@@ -1,6 +1,7 @@
 using PluginAPI;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -18,6 +19,7 @@ namespace LangEditor
         private string searchVal;
         private Dictionary<uint, string> dict;
         private Language _lang;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public Language Lang
         {
             get => _lang;

--- a/LangEditor/LangEditor.csproj
+++ b/LangEditor/LangEditor.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>

--- a/LoopModel/LoopModel.csproj
+++ b/LoopModel/LoopModel.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>

--- a/LoopModel/LoopModelEditor.cs
+++ b/LoopModel/LoopModelEditor.cs
@@ -1,6 +1,7 @@
 using PluginAPI;
 using ScottPlot;
 using System;
+using System.ComponentModel;
 using System.Windows.Forms;
 
 namespace LoopModel
@@ -28,6 +29,7 @@ namespace LoopModel
         private int selectedGraphIndex = 0;
 
         private LoopModelData _data;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public LoopModelData Data
         {
             get => _data;

--- a/LuaList/LuaList.csproj
+++ b/LuaList/LuaList.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>

--- a/LuaList/LuaListEditor.cs
+++ b/LuaList/LuaListEditor.cs
@@ -1,5 +1,6 @@
-using System.Windows.Forms;
 using PluginAPI;
+using System.ComponentModel;
+using System.Windows.Forms;
 
 namespace LuaList
 {
@@ -9,6 +10,7 @@ namespace LuaList
         public event Notify EditEvent;
 
         private LuaList _luaList;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public LuaList LuaList
         {
             get => _luaList;

--- a/MathLib/MathLib.csproj
+++ b/MathLib/MathLib.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>

--- a/ModelViewer/ModelViewer.csproj
+++ b/ModelViewer/ModelViewer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>

--- a/ModelViewer/SceneRenderControl.cs
+++ b/ModelViewer/SceneRenderControl.cs
@@ -8,7 +8,8 @@ namespace ModelViewer
     public partial class SceneRenderControl : UserControl
     {
         private GraphicsScene _graphicsScene;
-        
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public Scene Scene
         {
             get => _graphicsScene?.Scene;

--- a/PVSFormat/PVSEditControl.cs
+++ b/PVSFormat/PVSEditControl.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Drawing;
 using System.Numerics;
 using System.Windows.Forms;
@@ -9,6 +10,7 @@ namespace PVSFormat
     public class PVSEditControl : Control
     {
         private PVS _pvsFile;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public PVS PVS
         {
             get => _pvsFile;

--- a/PVSFormat/PVSEditor.cs
+++ b/PVSFormat/PVSEditor.cs
@@ -1,11 +1,12 @@
+using DebugHelper;
+using PluginAPI;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
 using System.Numerics;
 using System.Windows.Forms;
-using DebugHelper;
-using PluginAPI;
 
 namespace PVSFormat
 {
@@ -16,6 +17,7 @@ namespace PVSFormat
 
         private PVS _currentPVS;
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public Image GameMap
         {
             get => pvsMain.GameMap;

--- a/PVSFormat/PVSFormat.csproj
+++ b/PVSFormat/PVSFormat.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>

--- a/PluginAPI/PluginAPI.csproj
+++ b/PluginAPI/PluginAPI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>

--- a/PluginSystem/PluginSystem.csproj
+++ b/PluginSystem/PluginSystem.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/VaultFormat/AttribSysVaultForm.cs
+++ b/VaultFormat/AttribSysVaultForm.cs
@@ -1,12 +1,13 @@
-using System;
-using System.Collections;
-using System.Globalization;
-using System.Windows.Forms;
-using System.IO;
-using Newtonsoft.Json;
-using PluginAPI;
 using BundleUtilities;
 using LangEditor;
+using Newtonsoft.Json;
+using PluginAPI;
+using System;
+using System.Collections;
+using System.ComponentModel;
+using System.Globalization;
+using System.IO;
+using System.Windows.Forms;
 
 namespace VaultFormat
 {
@@ -21,6 +22,7 @@ namespace VaultFormat
         public event Notify EditEvent;
 
         private AttribSys _attribSys;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public AttribSys AttribSys
         {
             get => _attribSys;

--- a/VaultFormat/VaultFormat.csproj
+++ b/VaultFormat/VaultFormat.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>

--- a/VehicleList/VehicleEditor.cs
+++ b/VehicleList/VehicleEditor.cs
@@ -1,5 +1,6 @@
 using BundleUtilities;
 using System;
+using System.ComponentModel;
 using System.Windows.Forms;
 
 namespace VehicleList
@@ -9,6 +10,7 @@ namespace VehicleList
         public delegate void Done(Vehicle vehicle);
         public event Done OnDone;
         private Vehicle _vehicle;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public Vehicle Vehicle
         {
             get

--- a/VehicleList/VehicleList.csproj
+++ b/VehicleList/VehicleList.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>

--- a/VehicleList/VehicleListForm.cs
+++ b/VehicleList/VehicleListForm.cs
@@ -3,6 +3,7 @@ using PluginAPI;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using System.Windows.Forms;
@@ -17,6 +18,7 @@ namespace VehicleList
         private VehicleListData _list;
         private System.Windows.Forms.Timer _searchTimer;
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public VehicleListData List
         {
             get => _list;

--- a/WheelList/WheelEditor.cs
+++ b/WheelList/WheelEditor.cs
@@ -18,6 +18,7 @@ namespace WheelList
         public delegate void Done(Wheel wheel);
         public event Done OnDone;
         private Wheel _wheel;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public Wheel Wheel
         {
             get

--- a/WheelList/WheelList.csproj
+++ b/WheelList/WheelList.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/WheelList/WheelListForm.cs
+++ b/WheelList/WheelListForm.cs
@@ -20,6 +20,7 @@ namespace WheelList
         public event OnEdit Edit;
 
         private WheelListData _list;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public WheelListData List
         {
             get => _list;

--- a/WorldCollisionHandler/WorldColEditor.cs
+++ b/WorldCollisionHandler/WorldColEditor.cs
@@ -1,8 +1,9 @@
-using System;
-using System.Windows.Forms;
 using BundleUtilities;
 using DebugHelper;
 using PluginAPI;
+using System;
+using System.ComponentModel;
+using System.Windows.Forms;
 
 namespace WorldCollisionHandler
 {
@@ -12,6 +13,7 @@ namespace WorldCollisionHandler
         public event OnChanged Changed;
 
         private PolygonSoupList _poly;
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public PolygonSoupList Poly
         {
             get => _poly;

--- a/WorldCollisionHandler/WorldCollisionHandler.csproj
+++ b/WorldCollisionHandler/WorldCollisionHandler.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>


### PR DESCRIPTION
This adds a .NET 10 target (and .NET 9 because why not). Once merged, Visual Studio 2022 will not be able to build BM.

The only real change needed to make it work was to handle [WFO1000](https://learn.microsoft.com/en-us/dotnet/desktop/winforms/compiler-messages/wfo1000), which I did by annotating each property with `[DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]`. Since this moves from TargetFramework to TargetFrameworks, the plugin and shader Copy tasks had to be updated as well.

A couple unrelated changes were made: the removal of the one line of unsafe code so that AllowUnsafeBlocks could be disabled, and the addition of EditorConfig settings for project files.