### PR TITLE
Remove DebugHelper

### DIFF
--- a/BaseHandlers/BaseHandlers.csproj
+++ b/BaseHandlers/BaseHandlers.csproj
@@ -15,7 +15,6 @@
     <ProjectReference Include="..\PluginAPI\PluginAPI.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DebugHelper" Version="1.0.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
   </ItemGroup>
 </Project>

--- a/BaseHandlers/InstanceListEditor.cs
+++ b/BaseHandlers/InstanceListEditor.cs
@@ -1,6 +1,5 @@
 using BundleFormat;
 using BundleUtilities;
-using DebugHelper;
 using ModelViewer;
 using ModelViewer.SceneData;
 using PluginAPI;
@@ -238,7 +237,7 @@ namespace BaseHandlers
 
         private void DebugToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            DebugUtil.ShowDebug(this, InstanceList);
+            
         }
 
         private void LstMain_SizeChanged(object sender, EventArgs e)

--- a/BundleManager/BundleManager.csproj
+++ b/BundleManager/BundleManager.csproj
@@ -35,7 +35,6 @@
     <Content Include="icon.ico" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DebugHelper" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="ScottPlot.WinForms" Version="5.1.58" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
@@ -51,24 +50,8 @@
   </ItemGroup>
   <Target Name="Plugins" AfterTargets="Build" Condition="'$(TargetFramework)' != ''">
     <ItemGroup>
-      <PluginFiles Include="..\BaseHandlers\bin\$(Configuration)\$(TargetFramework)\BaseHandlers.dll;
-                            ..\BaseHandlers\bin\$(Configuration)\$(TargetFramework)\BaseHandlers.pdb;
-                            ..\LangEditor\bin\$(Configuration)\$(TargetFramework)\LangEditor.dll;
-                            ..\LangEditor\bin\$(Configuration)\$(TargetFramework)\LangEditor.pdb;
-                            ..\LoopModel\bin\$(Configuration)\$(TargetFramework)\LoopModel.dll;
-                            ..\LoopModel\bin\$(Configuration)\$(TargetFramework)\LoopModel.pdb;
-                            ..\LuaList\bin\$(Configuration)\$(TargetFramework)\LuaList.dll;
-                            ..\LuaList\bin\$(Configuration)\$(TargetFramework)\LuaList.pdb;
-                            ..\PVSFormat\bin\$(Configuration)\$(TargetFramework)\PVSFormat.dll;
-                            ..\PVSFormat\bin\$(Configuration)\$(TargetFramework)\PVSFormat.pdb;
-                            ..\VaultFormat\bin\$(Configuration)\$(TargetFramework)\VaultFormat.dll;
-                            ..\VaultFormat\bin\$(Configuration)\$(TargetFramework)\VaultFormat.pdb;
-                            ..\VehicleList\bin\$(Configuration)\$(TargetFramework)\VehicleList.dll;
-                            ..\VehicleList\bin\$(Configuration)\$(TargetFramework)\VehicleList.pdb;
-                            ..\WheelList\bin\$(Configuration)\$(TargetFramework)\WheelList.dll;
-                            ..\WheelList\bin\$(Configuration)\$(TargetFramework)\WheelList.pdb;
-                            ..\WorldCollisionHandler\bin\$(Configuration)\$(TargetFramework)\WorldCollisionHandler.dll;
-                            ..\WorldCollisionHandler\bin\$(Configuration)\$(TargetFramework)\WorldCollisionHandler.pdb" />
+      <PluginNames Include="BaseHandlers;LangEditor;LoopModel;LuaList;PVSFormat;VaultFormat;VehicleList;WheelList;WorldCollisionHandler" />
+      <PluginFiles Include="@(PluginNames -> '..\%(Identity)\bin\$(Configuration)\$(TargetFramework)\%(Identity).dll');@(PluginNames -> '..\%(Identity)\bin\$(Configuration)\$(TargetFramework)\%(Identity).pdb')" />
     </ItemGroup>
     <Copy SourceFiles="@(PluginFiles)" DestinationFolder="$(OutputPath)plugins" SkipUnchangedFiles="true" />
   </Target>

--- a/BundleManager/MainForm.cs
+++ b/BundleManager/MainForm.cs
@@ -1,14 +1,11 @@
 using System;
 using System.Collections;
 using System.ComponentModel;
-using System.IO;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using BundleFormat;
 using BundleUtilities;
-using DebugHelper;
 using PluginAPI;
 
 namespace BundleManager
@@ -445,15 +442,9 @@ namespace BundleManager
                         else
                         {
                             loader.Hide();
-                            if (forceDebug)
-                            {
-                                DebugUtil.ShowDebug(this, data);
-                            }
                             IEntryEditor editor = data.GetEditor(entry);
                             if (editor != null)
                                 editor.ShowDialog(this);
-                            else
-                                DebugUtil.ShowDebug(this, data);
                             if (ForceOnlySpecificEntry)
                                 Environment.Exit(0);
                         }

--- a/HexEditor/HexView.resx
+++ b/HexEditor/HexView.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/PVSFormat/PVSEditor.cs
+++ b/PVSFormat/PVSEditor.cs
@@ -1,10 +1,8 @@
-using DebugHelper;
 using PluginAPI;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
-using System.Linq;
 using System.Numerics;
 using System.Windows.Forms;
 

--- a/PVSFormat/PVSFormat.csproj
+++ b/PVSFormat/PVSFormat.csproj
@@ -18,7 +18,6 @@
     <ProjectReference Include="..\PluginAPI\PluginAPI.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DebugHelper" Version="1.0.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
   </ItemGroup>
 </Project>

--- a/WorldCollisionHandler/WorldColEditor.Designer.cs
+++ b/WorldCollisionHandler/WorldColEditor.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace WorldCollisionHandler
+namespace WorldCollisionHandler
 {
     partial class WorldColEditor
     {

--- a/WorldCollisionHandler/WorldColEditor.cs
+++ b/WorldCollisionHandler/WorldColEditor.cs
@@ -1,5 +1,4 @@
 using BundleUtilities;
-using DebugHelper;
 using PluginAPI;
 using System;
 using System.ComponentModel;
@@ -85,8 +84,7 @@ namespace WorldCollisionHandler
 
         private void debugInfoToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (_poly != null)
-                DebugUtil.ShowDebug(this, _poly);
+            
         }
 
         private void removeWreckSurfacesToolStripMenuItem_Click(object sender, EventArgs e)

--- a/WorldCollisionHandler/WorldCollisionHandler.csproj
+++ b/WorldCollisionHandler/WorldCollisionHandler.csproj
@@ -14,7 +14,6 @@
     <ProjectReference Include="..\PluginAPI\PluginAPI.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DebugHelper" Version="1.0.0" />
     <PackageReference Include="OpenTK" Version="4.9.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Removes DebugHelper as part of #105. This initial PR does not seek to replace it, only to remove it.

At the moment, the ModelViewer and WorldColEditor forms have been kept as-is because the designer is broken. This is likely due to #104. The "good" news is, while the designer may have worked before (not sure), the ModelViewer has been broken since an unknown point (see #103) and the WorldColEditor uses that... so for the end user, breaking the forms further doesn't change anything. That being the case, I'll be merging this as-is.