### PR TITLE
Revert "Remove unnecessary top-level packages"

### DIFF
--- a/BundleManager/BundleManager.csproj
+++ b/BundleManager/BundleManager.csproj
@@ -12,6 +12,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DebugHelper" Version="1.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="ScottPlot.WinForms" Version="5.1.58" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BundleFormat\BundleFormat.csproj" />


### PR DESCRIPTION
This reverts commit 60c72b0f3dc3d1c9cad74e66790ba92e6de0d772.

This was part of #110 but turned out to stop nuget dependencies from being copied. Having them in the main project is not the correct solution, though, just a stopgap measure. We should look into updating the plugin system.