### PR TITLE
Replace JSON and compression packages with built-in classes

### DIFF
--- a/BundleFormat/BundleEntry.cs
+++ b/BundleFormat/BundleEntry.cs
@@ -20,7 +20,7 @@ namespace BundleFormat
                     return null;
 
                 if (Compressed)
-                    return RawData.Decompress((int)UncompressedSize);
+                    return RawData.Decompress();
 
                 return RawData;
             }

--- a/BundleFormat/BundleFormat.csproj
+++ b/BundleFormat/BundleFormat.csproj
@@ -5,9 +5,6 @@
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="LibDeflate.NET" Version="1.19.0" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\BundleUtilities\BundleUtilities.csproj" />
   </ItemGroup>
 </Project>

--- a/BundleFormat/Extensions.cs
+++ b/BundleFormat/Extensions.cs
@@ -1,19 +1,15 @@
 using System;
-using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
 using System.Numerics;
 using System.Text;
-using System.Windows.Forms;
-using LibDeflate;
 
 namespace BundleFormat
 {
     public static class Extensions
     {
-        private static Decompressor decompressor = new ZlibDecompressor();
-        private static Compressor compressor = new ZlibCompressor(9);
-
         public static string AsString(this byte[] self)
         {
             if (self == null)
@@ -45,18 +41,23 @@ namespace BundleFormat
 
         public static byte[] Compress(this byte[] self)
         {
-            return compressor.Compress(self).Memory.ToArray();
+            MemoryStream uncompressed = new(self);
+            MemoryStream compressed = new();
+            using (ZLibStream zlibStream = new(compressed, CompressionLevel.SmallestSize, true))
+            {
+                uncompressed.CopyTo(zlibStream);
+            }
+            return compressed.ToArray();
         }
         
-        public static byte[] Decompress(this byte[] self, int uncompressedSize)
+        public static byte[] Decompress(this byte[] self)
         {
-            var status = decompressor.Decompress(self, uncompressedSize, out var owner, out var bytesRead);
-            if (status != OperationStatus.Done)
+            MemoryStream decompressed = new();
+            using (ZLibStream zlibStream = new(new MemoryStream(self), CompressionMode.Decompress))
             {
-                MessageBox.Show("Error decompressing data, status: " + status.ToString() + ", read: " + bytesRead.ToString(), "Error", MessageBoxButtons.OK);
-                return null;
+                zlibStream.CopyTo(decompressed);
             }
-            return owner.Memory.ToArray();
+            return decompressed.ToArray();
         }
 
         public static bool Matches(this byte[] self, byte[] other)

--- a/BundleManager/BundleManager.csproj
+++ b/BundleManager/BundleManager.csproj
@@ -12,7 +12,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DebugHelper" Version="1.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="ScottPlot.WinForms" Version="5.1.58" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
   </ItemGroup>

--- a/VaultFormat/AttribSysVaultForm.cs
+++ b/VaultFormat/AttribSysVaultForm.cs
@@ -1,12 +1,12 @@
 using BundleUtilities;
 using LangEditor;
-using Newtonsoft.Json;
 using PluginAPI;
 using System;
 using System.Collections;
 using System.ComponentModel;
 using System.Globalization;
 using System.IO;
+using System.Text.Json;
 using System.Windows.Forms;
 
 namespace VaultFormat
@@ -14,6 +14,11 @@ namespace VaultFormat
     public delegate void Notify();  // delegate
     public partial class AttribSysVaultForm : Form, IEntryEditor
     {
+        private readonly JsonSerializerOptions jsonSerializerOptions = new()
+        {
+            WriteIndented = true
+        };
+
         public AttribSysVaultForm()
         {
             InitializeComponent();
@@ -148,7 +153,8 @@ namespace VaultFormat
                 try
                 {
                     // Convertion of the AttribSys. Might need smarter structure to only keep the essential data concerning the configuration of the vehicle
-                    string jsonContent = JsonConvert.SerializeObject(AttribSys, Formatting.Indented);
+                    
+                    string jsonContent = JsonSerializer.Serialize(AttribSys, jsonSerializerOptions);
 
                     File.WriteAllText(saveDialog.FileName, jsonContent);
 

--- a/VaultFormat/VaultFormat.csproj
+++ b/VaultFormat/VaultFormat.csproj
@@ -5,9 +5,6 @@
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\BundleFormat\BundleFormat.csproj" />
     <ProjectReference Include="..\BundleUtilities\BundleUtilities.csproj" />
     <ProjectReference Include="..\LangEditor\LangEditor.csproj" />


### PR DESCRIPTION
* Replaces Newtonsoft.Json with System.Text.Json
* Replaces LibDeflate.NET with System.IO.Compression

Compression changes have been tested and confirmed to work. It's probably possible to optimize it, but I'll leave that for a potential future PR.

JSON hasn't been tested, but it's basically a drop-in replacement and only has one niche use, so I'm not too concerned.